### PR TITLE
Merge dev into main: auto-reporter cron job, system bot, and seed data

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "prisma:prepare": "pnpm prisma:generate && pnpm prisma:migrate",
     "start:dev": "nodemon --exec node -r ts-node/register -r tsconfig-paths/register --env-file=.env ./src/index.ts",
     "dev:poller": "nodemon --exec node -r ts-node/register -r tsconfig-paths/register --env-file=.env ./src/jobs/usgsPoller.ts",
+    "dev:auto-reporter": "nodemon --exec node -r ts-node/register -r tsconfig-paths/register --env-file=.env ./src/jobs/usgsAutoReporter.ts",
     "start:prod": "node ./build/index.js",
     "format": "prettier . --write --config ./.prettierrc && echo \"Success: format completed\"",
     "lint": "prettier --check . --config ./.prettierrc && eslint --max-warnings 0 . && echo \"Success: your code is clean\"",
@@ -85,7 +86,7 @@
     "typescript-eslint": "^8.0.0"
   },
   "prisma": {
-    "seed": "ts-node ./prisma/seed.ts"
+    "seed": "ts-node -r tsconfig-paths/register ./prisma/seed.ts"
   },
   "lint-staged": {
     "**/*": [

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,0 +1,82 @@
+import bcrypt from 'bcryptjs';
+import prisma from '@/libs/prisma';
+import { connectToMongoDB, closeMongoDBConnection } from '@/libs/mongo';
+import {
+  initRabbitMQConnection,
+  closeRabbitMQConnection,
+} from '@/libs/rabbitmqClient';
+import { ENV } from '@/env';
+import { seedDisasterReports } from '@/seed/seedDisasterReports';
+import { seedActivityPosts } from '@/seed/seedActivityPosts';
+import { seedResources } from '@/seed/seedResources';
+
+async function main() {
+  console.log('Starting Sentria seed...\n');
+
+  // 1. Initialize external connections (required by createDisasterReport which publishes to RabbitMQ)
+  console.log('Connecting to MongoDB...');
+  await connectToMongoDB();
+  console.log('MongoDB connected.\n');
+
+  console.log('Connecting to RabbitMQ...');
+  await initRabbitMQConnection();
+  console.log('RabbitMQ connected.\n');
+
+  // 2. Upsert system bot user (idempotent)
+  console.log('Upserting system bot user...');
+  const hashedPassword = await bcrypt.hash(ENV.SYSTEM_BOT_PASSWORD, 10);
+
+  const systemUser = await prisma.user.upsert({
+    where: { email: ENV.SYSTEM_BOT_EMAIL },
+    update: {
+      username: ENV.SYSTEM_BOT_USERNAME,
+      firstName: ENV.SYSTEM_BOT_FIRST_NAME,
+      lastName: ENV.SYSTEM_BOT_LAST_NAME,
+      password: hashedPassword,
+      email_verified: true,
+      verified_profile: true,
+    },
+    create: {
+      email: ENV.SYSTEM_BOT_EMAIL,
+      username: ENV.SYSTEM_BOT_USERNAME,
+      firstName: ENV.SYSTEM_BOT_FIRST_NAME,
+      lastName: ENV.SYSTEM_BOT_LAST_NAME,
+      password: hashedPassword,
+      birthday: new Date('2000-01-01'),
+      country: 'Global',
+      email_verified: true,
+      verified_profile: true,
+    },
+  });
+
+  console.log(
+    `System bot user ready: ${systemUser.id} (${systemUser.email})\n`,
+  );
+
+  // 3. Seed disaster reports (fetches from ReliefWeb + EONET, publishes to RabbitMQ)
+  const disasterLocations = await seedDisasterReports(systemUser);
+
+  // 4. Seed activity posts near disaster epicenters
+  await seedActivityPosts(systemUser.id, disasterLocations);
+
+  // 5. Seed emergency resources
+  await seedResources(systemUser);
+
+  // --- Summary ---
+  console.log('=== Seed Summary ===');
+  console.log(`  Disaster locations seeded: ${disasterLocations.length}`);
+  console.log('  Activity posts: up to 10 (5 REQUEST + 5 OFFER)');
+  console.log('  Resources: up to 9 (4 HOTLINE + 3 SURVIVAL + 2 FIRST_AID)');
+  console.log('\nSeed completed successfully!');
+}
+
+main()
+  .catch((error) => {
+    console.error('Seed failed:', error);
+    process.exit(1);
+  })
+  .finally(async () => {
+    await closeRabbitMQConnection();
+    await closeMongoDBConnection();
+    await prisma.$disconnect();
+  });

--- a/src/controllers/commentReplies/commentReplyController.ts
+++ b/src/controllers/commentReplies/commentReplyController.ts
@@ -90,7 +90,15 @@ export async function getCommentRepliesByCommentId(
     if (!commentId) {
       throw new NotFoundError('Comment ID is required');
     }
-    const result = await commentReplyService.getCommentReplies(commentId);
+
+    const limit = Math.max(1, parseInt(req.query.limit as string) || 5);
+    const skip = Math.max(0, parseInt(req.query.skip as string) || 0);
+
+    const result = await commentReplyService.getCommentReplies(
+      commentId,
+      limit,
+      skip,
+    );
     return res.status(200).json({ result });
   } catch (error) {
     logger.error(`Error getting comment replies: ${error}`);

--- a/src/controllers/user/user.ts
+++ b/src/controllers/user/user.ts
@@ -2,7 +2,7 @@ import { deleteFromSupabase, uploadToSupabase } from '@/services/user/upload';
 import * as userService from '@/services/user/user';
 import { ValidationError } from '@/utils/errors';
 import { NextFunction, Request, Response } from 'express';
-import { ZodError, boolean, date, object, string } from 'zod';
+import { ZodError, boolean, coerce, object, string } from 'zod';
 
 const userDetailSchema = object({
   firstName: string().optional(),
@@ -12,7 +12,7 @@ const userDetailSchema = object({
   email_verified: boolean().optional(),
   password: string().min(8).optional(),
   verified_profile: boolean().optional(),
-  birthday: date().nullable().optional(),
+  birthday: coerce.date().nullable().optional(),
   country: string().optional(),
 });
 

--- a/src/env.ts
+++ b/src/env.ts
@@ -23,6 +23,13 @@ export const ENV = {
     process.env.RABBITMQ_NOTIFICATION_QUEUE_NAME ||
     'sentria_send_notification_jobs',
   REDIS_URL: process.env.REDIS_URL || 'redis://localhost:6379',
+
+  // System Bot
+  SYSTEM_BOT_EMAIL: process.env.SYSTEM_BOT_EMAIL || 'system@sentria.app',
+  SYSTEM_BOT_PASSWORD: process.env.SYSTEM_BOT_PASSWORD || 'S3ntr1a_Sys_B0t!2025',
+  SYSTEM_BOT_USERNAME: process.env.SYSTEM_BOT_USERNAME || 'sentria_alerts',
+  SYSTEM_BOT_FIRST_NAME: process.env.SYSTEM_BOT_FIRST_NAME || 'Sentria',
+  SYSTEM_BOT_LAST_NAME: process.env.SYSTEM_BOT_LAST_NAME || 'Alert System',
 };
 
 if (ENV.NODE_ENV === 'local' && !process.env.CORS_ORIGIN) {

--- a/src/jobs/usgsAutoReporter.ts
+++ b/src/jobs/usgsAutoReporter.ts
@@ -78,10 +78,34 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Parse city/country from the USGS `place` string as a fallback.
+ * Examples:
+ *   "115 km ESE of Petropavlovsk-Kamchatsky, Russia" → { city: "Petropavlovsk-Kamchatsky", country: "Russia" }
+ *   "South Sandwich Islands region" → { city: "South Sandwich Islands region", country: "South Sandwich Islands region" }
+ */
+function parseUsgsPlace(place: string): { city: string; country: string } {
+  // Pattern: "X km DIR of City, Country"
+  const ofMatch = place.match(/of\s+(.+),\s+(.+)$/);
+  if (ofMatch) {
+    return { city: ofMatch[1].trim(), country: ofMatch[2].trim() };
+  }
+  // Pattern: "City, Country" (no distance prefix)
+  const commaMatch = place.match(/^(.+),\s+(.+)$/);
+  if (commaMatch) {
+    return { city: commaMatch[1].trim(), country: commaMatch[2].trim() };
+  }
+  // Fallback: use the entire place string for both
+  return { city: place, country: place };
+}
+
 async function reverseGeocode(
   lat: number,
   lon: number,
+  usgsPlace: string,
 ): Promise<{ city: string; country: string }> {
+  const fallback = parseUsgsPlace(usgsPlace);
+
   try {
     const response = await axios.get<NominatimResponse>(NOMINATIM_BASE_URL, {
       params: {
@@ -102,15 +126,15 @@ async function reverseGeocode(
       address?.village ||
       address?.county ||
       address?.state ||
-      'Unknown';
-    const country = address?.country || 'Unknown';
+      fallback.city;
+    const country = address?.country || fallback.country;
 
     return { city, country };
   } catch (error) {
     logger.warn(
-      `[USGSAutoReporter] Nominatim reverse geocode failed for ${lat},${lon}: ${error instanceof Error ? error.message : String(error)}`,
+      `[USGSAutoReporter] Nominatim reverse geocode failed for ${lat},${lon}, using USGS place fallback: ${error instanceof Error ? error.message : String(error)}`,
     );
-    return { city: 'Unknown', country: 'Unknown' };
+    return fallback;
   }
 }
 
@@ -176,8 +200,8 @@ async function processNewEarthquakes() {
         `[USGSAutoReporter] Processing new event: M${magnitude.toFixed(1)} - ${props.place}`,
       );
 
-      // Reverse geocode with Nominatim (1 req/sec rate limit)
-      const { city, country } = await reverseGeocode(lat, lon);
+      // Reverse geocode with Nominatim (1 req/sec rate limit), falls back to USGS place string
+      const { city, country } = await reverseGeocode(lat, lon, props.place);
       await sleep(1000); // respect Nominatim rate limit
 
       const severity = mapSeverity(magnitude);

--- a/src/jobs/usgsAutoReporter.ts
+++ b/src/jobs/usgsAutoReporter.ts
@@ -1,0 +1,283 @@
+import { ENV } from '@/env';
+import prisma from '@/libs/prisma';
+import { connectToMongoDB, closeMongoDBConnection } from '@/libs/mongo';
+import {
+  closeRabbitMQConnection,
+  initRabbitMQConnection,
+} from '@/libs/rabbitmqClient';
+import { getRedisClient, initRedisConnection } from '@/libs/redisClient';
+import logger from '@/logger';
+import {
+  createDisasterReport,
+  ValidatedDisasterPayload,
+} from '@/services/disasterReports/disasterReports';
+import axios from 'axios';
+import cron from 'node-cron';
+import { User } from '@prisma/client';
+
+const USGS_SIGNIFICANT_EQ_URL =
+  'https://earthquake.usgs.gov/earthquakes/feed/v1.0/summary/4.5_day.geojson';
+const AUTO_REPORT_KEY_PREFIX = 'sentria:auto-report:';
+const DEDUP_TTL_SECONDS = 7 * 24 * 60 * 60; // 7 days
+const POLLING_INTERVAL_MINUTES = 10;
+const NOMINATIM_BASE_URL = 'https://nominatim.openstreetmap.org/reverse';
+
+interface UsgsFeature {
+  id: string;
+  properties: {
+    mag: number;
+    place: string;
+    time: number;
+    url: string;
+  };
+  geometry: {
+    type: 'Point';
+    coordinates: [number, number, number]; // [longitude, latitude, depth]
+  };
+}
+
+interface UsgsFeatureCollection {
+  features: UsgsFeature[];
+}
+
+interface NominatimResponse {
+  address?: {
+    city?: string;
+    town?: string;
+    village?: string;
+    county?: string;
+    state?: string;
+    country?: string;
+    country_code?: string;
+  };
+  display_name?: string;
+}
+
+function mapSeverity(magnitude: number): 'MINOR' | 'MODERATE' | 'SEVERE' {
+  if (magnitude < 5.0) return 'MINOR';
+  if (magnitude <= 6.0) return 'MODERATE';
+  return 'SEVERE';
+}
+
+function buildDescription(
+  mag: number,
+  place: string,
+  depthKm: number,
+  time: number,
+  url: string,
+): string {
+  const utcTime = new Date(time).toISOString();
+  return (
+    `A magnitude ${mag.toFixed(1)} earthquake was recorded ${place} at a depth of ${depthKm.toFixed(1)} km.\n` +
+    `This event was detected at ${utcTime} by the USGS earthquake monitoring system.\n\n` +
+    `Source: USGS (${url})`
+  );
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function reverseGeocode(
+  lat: number,
+  lon: number,
+): Promise<{ city: string; country: string }> {
+  try {
+    const response = await axios.get<NominatimResponse>(NOMINATIM_BASE_URL, {
+      params: {
+        lat,
+        lon,
+        format: 'json',
+      },
+      headers: {
+        'User-Agent': 'Sentria-DisasterPlatform/1.0 (system@sentria.app)',
+      },
+      timeout: 10000,
+    });
+
+    const address = response.data?.address;
+    const city =
+      address?.city ||
+      address?.town ||
+      address?.village ||
+      address?.county ||
+      address?.state ||
+      'Unknown';
+    const country = address?.country || 'Unknown';
+
+    return { city, country };
+  } catch (error) {
+    logger.warn(
+      `[USGSAutoReporter] Nominatim reverse geocode failed for ${lat},${lon}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return { city: 'Unknown', country: 'Unknown' };
+  }
+}
+
+let systemBotUser: User | null = null;
+
+async function getSystemBotUser(): Promise<User> {
+  if (systemBotUser) return systemBotUser;
+
+  const user = await prisma.user.findUnique({
+    where: { email: ENV.SYSTEM_BOT_EMAIL },
+  });
+
+  if (!user) {
+    throw new Error(
+      `[USGSAutoReporter] System bot user not found for email: ${ENV.SYSTEM_BOT_EMAIL}. Ensure seed has run.`,
+    );
+  }
+
+  systemBotUser = user;
+  logger.info(
+    `[USGSAutoReporter] System bot user loaded: ${user.id} (${user.email})`,
+  );
+  return user;
+}
+
+async function processNewEarthquakes() {
+  logger.info(`[USGSAutoReporter] Starting a new polling cycle...`);
+  try {
+    const redis = getRedisClient();
+
+    const response =
+      await axios.get<UsgsFeatureCollection>(USGS_SIGNIFICANT_EQ_URL);
+    const earthquakes = response.data.features;
+
+    if (!earthquakes || earthquakes.length === 0) {
+      logger.info(
+        `[USGSAutoReporter] No M4.5+ earthquakes from last 24 hours`,
+      );
+      return;
+    }
+
+    logger.info(
+      `[USGSAutoReporter] Fetched ${earthquakes.length} M4.5+ events from USGS`,
+    );
+
+    const botUser = await getSystemBotUser();
+    let newReportsCreated = 0;
+
+    for (const earthquake of earthquakes) {
+      const eventId = earthquake.id;
+      const eventKey = `${AUTO_REPORT_KEY_PREFIX}${eventId}`;
+
+      const alreadyProcessed = await redis.get(eventKey);
+      if (alreadyProcessed) {
+        continue;
+      }
+
+      const props = earthquake.properties;
+      const [lon, lat, depthKm] = earthquake.geometry.coordinates;
+      const magnitude = props.mag;
+
+      logger.info(
+        `[USGSAutoReporter] Processing new event: M${magnitude.toFixed(1)} - ${props.place}`,
+      );
+
+      // Reverse geocode with Nominatim (1 req/sec rate limit)
+      const { city, country } = await reverseGeocode(lat, lon);
+      await sleep(1000); // respect Nominatim rate limit
+
+      const severity = mapSeverity(magnitude);
+      const description = buildDescription(
+        magnitude,
+        props.place,
+        depthKm,
+        props.time,
+        props.url,
+      );
+      const reportName = `M${magnitude.toFixed(1)} Earthquake - ${props.place}`;
+
+      const payload: ValidatedDisasterPayload = {
+        reportName,
+        description,
+        incidentType: 'EARTHQUAKE',
+        severity,
+        incidentTimestamp: new Date(props.time),
+        location: {
+          type: 'Point',
+          coordinates: [lon, lat],
+        },
+        country,
+        city,
+        media: [],
+      };
+
+      try {
+        await createDisasterReport(payload, reportName, botUser);
+        logger.info(
+          `[USGSAutoReporter] Successfully created report for event ${eventId}: ${reportName}`,
+        );
+        newReportsCreated++;
+      } catch (reportError) {
+        logger.error(
+          `[USGSAutoReporter] Failed to create report for event ${eventId}: ${reportError instanceof Error ? reportError.message : String(reportError)}`,
+        );
+      }
+
+      // Mark as processed regardless of report creation success to avoid retrying bad data
+      await redis.set(eventKey, 'processed', { EX: DEDUP_TTL_SECONDS });
+    }
+
+    if (newReportsCreated > 0) {
+      logger.info(
+        `[USGSAutoReporter] Created ${newReportsCreated} new disaster report(s) this cycle`,
+      );
+    }
+  } catch (error) {
+    logger.error(
+      '[USGSAutoReporter] Error during polling cycle: ',
+      error,
+    );
+  } finally {
+    logger.info('[USGSAutoReporter] Polling cycle finished');
+  }
+}
+
+async function startAutoReporterService() {
+  logger.info(`[USGSAutoReporter] Initializing service...`);
+  try {
+    await initRedisConnection();
+    await initRabbitMQConnection();
+    await connectToMongoDB();
+    logger.info(`[USGSAutoReporter] Dependencies initialized...`);
+
+    cron.schedule(
+      `*/${POLLING_INTERVAL_MINUTES} * * * *`,
+      processNewEarthquakes,
+    );
+
+    logger.info(
+      `[USGSAutoReporter] Service started. CRON job scheduled to run every ${POLLING_INTERVAL_MINUTES} minute(s).`,
+    );
+
+    // Run once immediately on startup
+    logger.info(`[USGSAutoReporter] Running initial check on startup...`);
+    processNewEarthquakes();
+  } catch (error) {
+    logger.error(
+      `[USGSAutoReporter] CRITICAL: Failed to init dependencies. Service will not start: `,
+      error,
+    );
+    process.exit(1);
+  }
+}
+
+// Handle graceful shutdown for this separate process
+const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+signals.forEach((signal) => {
+  process.on(signal, async () => {
+    logger.info(`[USGSAutoReporter] Received ${signal}. Shutting down...`);
+    await closeRabbitMQConnection();
+    const redis = getRedisClient();
+    if (redis.isOpen) await redis.quit();
+    await closeMongoDBConnection();
+    await prisma.$disconnect();
+    logger.info('[USGSAutoReporter] All connections closed. Exiting.');
+    process.exit(0);
+  });
+});
+
+startAutoReporterService();

--- a/src/seed/seedActivityPosts.ts
+++ b/src/seed/seedActivityPosts.ts
@@ -1,0 +1,148 @@
+import { CreatePost } from '@/services/activity/activityFeed';
+import prisma from '@/libs/prisma';
+import { DisasterLocation } from './seedDisasterReports';
+
+const REQUEST_POSTS = [
+  {
+    description:
+      'Urgently need clean drinking water for 50 families displaced by the disaster. Water supply has been contaminated and children are at risk of dehydration.',
+    helpType: 'WATER' as const,
+    quantity: 50,
+  },
+  {
+    description:
+      'Emergency food supplies needed for evacuation center. Over 200 people have not eaten in 24 hours. Rice, canned goods, and baby formula urgently needed.',
+    helpType: 'FOOD' as const,
+    quantity: 200,
+  },
+  {
+    description:
+      'Temporary shelter needed for families who lost their homes. Children and elderly need immediate cover from the elements.',
+    helpType: 'SHELTER' as const,
+    quantity: 30,
+  },
+  {
+    description:
+      'Need food packages and baby formula for displaced mothers and infants at the main relief camp. Medical nutrition supplements also welcome.',
+    helpType: 'FOOD' as const,
+    quantity: 100,
+  },
+  {
+    description:
+      'WiFi and internet access needed at evacuation center for people to contact family members and access emergency information services.',
+    helpType: 'WIFI' as const,
+    quantity: 5,
+  },
+];
+
+const OFFER_POSTS = [
+  {
+    description:
+      'We have 100 water bottles and 50 water purification tablets available for immediate delivery to affected areas. Contact for pickup or delivery.',
+    helpType: 'WATER' as const,
+    quantity: 100,
+  },
+  {
+    description:
+      'Local restaurant offering free hot meals for disaster survivors. Can serve 150 people per day. Located 2km from the evacuation zone.',
+    helpType: 'FOOD' as const,
+    quantity: 150,
+  },
+  {
+    description:
+      'Community hall available as temporary shelter. Can accommodate 80 people with basic facilities, running water, and first aid kit on site.',
+    helpType: 'SHELTER' as const,
+    quantity: 80,
+  },
+  {
+    description:
+      'Free WiFi hotspot set up near the disaster area. Powered by generator and available 24/7 for emergency communication and coordination.',
+    helpType: 'WIFI' as const,
+    quantity: 3,
+  },
+  {
+    description:
+      'Offering cooked meals and ready-to-eat food packs for affected families. Can deliver within 10km radius of the disaster area daily.',
+    helpType: 'FOOD' as const,
+    quantity: 75,
+  },
+];
+
+export async function seedActivityPosts(
+  systemUserId: string,
+  disasterLocations: DisasterLocation[],
+): Promise<void> {
+  console.log('--- Seeding Activity Posts ---');
+
+  // Idempotency: skip if system user already has posts
+  const existingCount = await prisma.activityFeedPost.count({
+    where: { postedById: systemUserId },
+  });
+  if (existingCount > 0) {
+    console.log(
+      `  System user already has ${existingCount} posts, skipping\n`,
+    );
+    return;
+  }
+
+  if (disasterLocations.length === 0) {
+    console.log('  No disaster locations available, skipping activity posts\n');
+    return;
+  }
+
+  let created = 0;
+
+  // Create REQUEST posts near disaster epicenters
+  for (let i = 0; i < REQUEST_POSTS.length; i++) {
+    const post = REQUEST_POSTS[i];
+    const location = disasterLocations[i % disasterLocations.length];
+    const offsetLat = location.latitude + (Math.random() * 0.1 - 0.05);
+    const offsetLng = location.longitude + (Math.random() * 0.1 - 0.05);
+
+    try {
+      await CreatePost(systemUserId, {
+        activityType: 'REQUEST',
+        description: post.description,
+        location: {
+          city: location.city,
+          country: location.country,
+          latitude: parseFloat(offsetLat.toFixed(6)),
+          longitude: parseFloat(offsetLng.toFixed(6)),
+        },
+        helpItems: [{ helpType: post.helpType, quantity: post.quantity }],
+      });
+      created++;
+      console.log(`  Created REQUEST post: ${post.helpType}`);
+    } catch (error) {
+      console.error(`  Failed to create REQUEST post (${post.helpType}):`, error);
+    }
+  }
+
+  // Create OFFER posts from nearby cities
+  for (let i = 0; i < OFFER_POSTS.length; i++) {
+    const post = OFFER_POSTS[i];
+    const location = disasterLocations[i % disasterLocations.length];
+    const offsetLat = location.latitude + (Math.random() * 0.1 - 0.05);
+    const offsetLng = location.longitude + (Math.random() * 0.1 - 0.05);
+
+    try {
+      await CreatePost(systemUserId, {
+        activityType: 'OFFER',
+        description: post.description,
+        location: {
+          city: location.city,
+          country: location.country,
+          latitude: parseFloat(offsetLat.toFixed(6)),
+          longitude: parseFloat(offsetLng.toFixed(6)),
+        },
+        helpItems: [{ helpType: post.helpType, quantity: post.quantity }],
+      });
+      created++;
+      console.log(`  Created OFFER post: ${post.helpType}`);
+    } catch (error) {
+      console.error(`  Failed to create OFFER post (${post.helpType}):`, error);
+    }
+  }
+
+  console.log(`  Created ${created} activity posts\n`);
+}

--- a/src/seed/seedDisasterReports.ts
+++ b/src/seed/seedDisasterReports.ts
@@ -1,0 +1,288 @@
+import axios from 'axios';
+import prisma from '@/libs/prisma';
+import {
+  createDisasterReport,
+  ValidatedDisasterPayload,
+} from '@/services/disasterReports/disasterReports';
+import { DISASTER_INCIDENT_TYPE } from '@/types/reports';
+import { User } from '@prisma/client';
+
+export interface DisasterLocation {
+  latitude: number;
+  longitude: number;
+  city: string;
+  country: string;
+}
+
+// --- ReliefWeb API types ---
+interface ReliefWebDisaster {
+  fields: {
+    name: string;
+    description?: string;
+    type?: Array<{ name: string }>;
+    country?: Array<{ name: string }>;
+    date?: { created: string };
+    glide?: string;
+  };
+}
+
+interface ReliefWebResponse {
+  data: ReliefWebDisaster[];
+}
+
+// --- NASA EONET types ---
+interface EONETEvent {
+  title: string;
+  description?: string | null;
+  categories: Array<{ title: string }>;
+  geometry: Array<{ coordinates: [number, number]; date: string }>;
+}
+
+interface EONETResponse {
+  events: EONETEvent[];
+}
+
+function mapDisasterType(typeStr: string): DISASTER_INCIDENT_TYPE {
+  const normalized = typeStr.toLowerCase();
+  if (normalized.includes('earthquake')) return 'EARTHQUAKE';
+  if (normalized.includes('flood')) return 'FLOOD';
+  if (
+    normalized.includes('cyclone') ||
+    normalized.includes('storm') ||
+    normalized.includes('hurricane') ||
+    normalized.includes('typhoon')
+  )
+    return 'STORM';
+  if (
+    normalized.includes('wildfire') ||
+    normalized.includes('fire') ||
+    normalized.includes('volcano')
+  )
+    return 'FIRE';
+  return 'OTHER';
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function geocodeQuery(
+  query: string,
+): Promise<{ lat: number; lng: number } | null> {
+  try {
+    const { data } = await axios.get(
+      'https://nominatim.openstreetmap.org/search',
+      {
+        params: { format: 'json', q: query, limit: 1 },
+        headers: { 'User-Agent': 'Sentria/1.0 (system@sentria.app)' },
+      },
+    );
+    if (data.length > 0) {
+      return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) };
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+async function reverseGeocode(
+  lat: number,
+  lng: number,
+): Promise<{ city: string; country: string }> {
+  try {
+    const { data } = await axios.get(
+      'https://nominatim.openstreetmap.org/reverse',
+      {
+        params: { format: 'json', lat, lon: lng, zoom: 10 },
+        headers: { 'User-Agent': 'Sentria/1.0 (system@sentria.app)' },
+      },
+    );
+    const address = data.address || {};
+    return {
+      city:
+        address.city ||
+        address.town ||
+        address.village ||
+        address.state ||
+        'Unknown',
+      country: address.country || 'Unknown',
+    };
+  } catch {
+    return { city: 'Unknown', country: 'Unknown' };
+  }
+}
+
+async function reportExists(name: string): Promise<boolean> {
+  const existing = await prisma.report.findFirst({ where: { name } });
+  return existing !== null;
+}
+
+export async function seedDisasterReports(
+  systemUser: User,
+): Promise<DisasterLocation[]> {
+  console.log('--- Seeding Disaster Reports ---');
+  const locations: DisasterLocation[] = [];
+
+  // --- Fetch from ReliefWeb ---
+  let reliefWebDisasters: ReliefWebDisaster[] = [];
+  try {
+    console.log('  Fetching from ReliefWeb API...');
+    const { data } = await axios.get<ReliefWebResponse>(
+      'https://api.reliefweb.int/v1/disasters',
+      {
+        params: {
+          appname: 'sentria',
+          limit: 10,
+          'filter[field]': 'status',
+          'filter[value]': 'current',
+          'sort[]': 'date:desc',
+          'fields[include][]': [
+            'name',
+            'description',
+            'type',
+            'country',
+            'date',
+            'glide',
+          ],
+        },
+      },
+    );
+    reliefWebDisasters = data.data || [];
+    console.log(
+      `  Fetched ${reliefWebDisasters.length} disasters from ReliefWeb`,
+    );
+  } catch (error) {
+    console.error('  Failed to fetch from ReliefWeb:', error);
+  }
+
+  // --- Fetch from NASA EONET ---
+  let eonetEvents: EONETEvent[] = [];
+  try {
+    console.log('  Fetching from NASA EONET API...');
+    const { data } = await axios.get<EONETResponse>(
+      'https://eonet.gsfc.nasa.gov/api/v3/events',
+      { params: { status: 'open', limit: 5 } },
+    );
+    eonetEvents = data.events || [];
+    console.log(`  Fetched ${eonetEvents.length} events from NASA EONET`);
+  } catch (error) {
+    console.error('  Failed to fetch from NASA EONET:', error);
+  }
+
+  // --- Process ReliefWeb disasters ---
+  for (const disaster of reliefWebDisasters) {
+    const name = disaster.fields.name;
+
+    if (await reportExists(name)) {
+      console.log(`  Skipping "${name}" - already exists`);
+      continue;
+    }
+
+    const typeStr = disaster.fields.type?.[0]?.name || 'Other';
+    const incidentType = mapDisasterType(typeStr);
+    const countryName = disaster.fields.country?.[0]?.name || 'Unknown';
+    const dateStr = disaster.fields.date?.created || new Date().toISOString();
+    const rawDescription = disaster.fields.description || '';
+    const description =
+      rawDescription.length >= 10
+        ? rawDescription.substring(0, 5000)
+        : `${name} - ${typeStr} disaster reported in ${countryName}. Ongoing situation requiring monitoring and response.`;
+
+    let lat = 0;
+    let lng = 0;
+    let city = countryName;
+
+    // Geocode country name to get approximate coordinates
+    const geoResult = await geocodeQuery(countryName);
+    if (geoResult) {
+      lat = geoResult.lat;
+      lng = geoResult.lng;
+      await delay(1100); // Nominatim rate limit: 1 req/sec
+      const reverseResult = await reverseGeocode(lat, lng);
+      city = reverseResult.city;
+    }
+    await delay(1100);
+
+    const payload: ValidatedDisasterPayload = {
+      reportName: name,
+      description,
+      incidentType,
+      severity: 'MODERATE',
+      incidentTimestamp: new Date(dateStr),
+      location: { type: 'Point', coordinates: [lng, lat] },
+      country: countryName,
+      city,
+      media: [],
+    };
+
+    try {
+      console.log(`  Creating report: "${name}"`);
+      await createDisasterReport(payload, name, systemUser);
+      locations.push({ latitude: lat, longitude: lng, city, country: countryName });
+    } catch (error) {
+      console.error(`  Failed to create report "${name}":`, error);
+    }
+  }
+
+  // --- Process EONET events ---
+  for (const event of eonetEvents) {
+    const name = event.title;
+
+    if (await reportExists(name)) {
+      console.log(`  Skipping EONET "${name}" - already exists`);
+      continue;
+    }
+
+    const categoryTitle = event.categories?.[0]?.title || 'Other';
+    const incidentType = mapDisasterType(categoryTitle);
+    const geometry = event.geometry?.[0];
+
+    if (!geometry) {
+      console.warn(`  Skipping EONET "${name}" - no geometry data`);
+      continue;
+    }
+
+    const [lng, lat] = geometry.coordinates;
+    const dateStr = geometry.date || new Date().toISOString();
+
+    let city = 'Unknown';
+    let country = 'Unknown';
+    try {
+      await delay(1100);
+      const result = await reverseGeocode(lat, lng);
+      city = result.city;
+      country = result.country;
+    } catch {
+      console.warn(`  Could not reverse geocode for "${name}"`);
+    }
+
+    const description =
+      event.description && event.description.length >= 10
+        ? event.description.substring(0, 5000)
+        : `${name} - ${categoryTitle} event detected by NASA EONET near ${city}, ${country}. Active monitoring in progress.`;
+
+    const payload: ValidatedDisasterPayload = {
+      reportName: name,
+      description,
+      incidentType,
+      severity: 'MODERATE',
+      incidentTimestamp: new Date(dateStr),
+      location: { type: 'Point', coordinates: [lng, lat] },
+      country,
+      city,
+      media: [],
+    };
+
+    try {
+      console.log(`  Creating EONET report: "${name}"`);
+      await createDisasterReport(payload, name, systemUser);
+      locations.push({ latitude: lat, longitude: lng, city, country });
+    } catch (error) {
+      console.error(`  Failed to create EONET report "${name}":`, error);
+    }
+  }
+
+  console.log(`  Created ${locations.length} disaster reports\n`);
+  return locations;
+}

--- a/src/seed/seedResources.ts
+++ b/src/seed/seedResources.ts
@@ -1,0 +1,149 @@
+import prisma from '@/libs/prisma';
+import { createResource } from '@/services/resources/resources';
+import { User } from '@prisma/client';
+
+interface ResourceSeedEntry {
+  name: string;
+  description: string;
+  resourceType: 'SURVIVAL' | 'HOTLINE' | 'FIRST_AID';
+  coordinates: [number, number]; // [lng, lat]
+  address: {
+    city: string;
+    country: string;
+    fullAddress?: string;
+  };
+}
+
+const SEED_RESOURCES: ResourceSeedEntry[] = [
+  // --- HOTLINE entries ---
+  {
+    name: 'Myanmar Emergency Hotline (191)',
+    description:
+      'Myanmar National Emergency Hotline. Call 191 for police, fire, and medical emergencies across Myanmar. Available 24/7 in Burmese and English.',
+    resourceType: 'HOTLINE',
+    coordinates: [96.1561, 16.8661], // Yangon
+    address: {
+      city: 'Yangon',
+      country: 'Myanmar',
+      fullAddress: 'Myanmar National Emergency Services',
+    },
+  },
+  {
+    name: 'Philippines Emergency Hotline (911)',
+    description:
+      'Philippines National Emergency Hotline. Dial 911 for police, fire, medical, and disaster response. Operates 24/7 nationwide in Filipino and English.',
+    resourceType: 'HOTLINE',
+    coordinates: [120.9842, 14.5995], // Manila
+    address: {
+      city: 'Manila',
+      country: 'Philippines',
+      fullAddress: 'Philippine National Police / Bureau of Fire Protection',
+    },
+  },
+  {
+    name: 'Indonesia Emergency Hotline (117)',
+    description:
+      'Indonesia Search and Rescue Emergency Number. Call 117 for natural disaster rescue operations, missing persons, and emergency evacuations.',
+    resourceType: 'HOTLINE',
+    coordinates: [106.845, -6.2088], // Jakarta
+    address: {
+      city: 'Jakarta',
+      country: 'Indonesia',
+      fullAddress: 'BASARNAS - Badan Nasional Pencarian dan Pertolongan',
+    },
+  },
+  {
+    name: 'Japan Emergency Hotline (110 / 119)',
+    description:
+      'Japan Emergency Services. Call 110 for police emergencies and 119 for fire and ambulance. English support available in major cities through translation services.',
+    resourceType: 'HOTLINE',
+    coordinates: [139.6917, 35.6895], // Tokyo
+    address: {
+      city: 'Tokyo',
+      country: 'Japan',
+      fullAddress: 'National Police Agency / Fire and Disaster Management Agency',
+    },
+  },
+
+  // --- SURVIVAL guides ---
+  {
+    name: 'Earthquake Safety: Drop, Cover, Hold On',
+    description:
+      'During an earthquake: DROP to the ground, take COVER under a sturdy desk or table, and HOLD ON until the shaking stops. Stay away from windows, heavy furniture, and exterior walls. If outdoors, move to an open area away from buildings. After shaking stops, check for injuries and be prepared for aftershocks. Do not use elevators.',
+    resourceType: 'SURVIVAL',
+    coordinates: [0, 0],
+    address: { city: 'Global', country: 'Global' },
+  },
+  {
+    name: 'Flood Evacuation Procedures',
+    description:
+      'If flooding is imminent: move immediately to higher ground. Do not walk, swim, or drive through flood waters - just 6 inches of moving water can knock you down. Disconnect electrical appliances. Avoid contact with floodwater as it may be contaminated. If trapped in a building, go to the highest level but do not climb into a closed attic. Signal for help from a window or rooftop.',
+    resourceType: 'SURVIVAL',
+    coordinates: [0, 0],
+    address: { city: 'Global', country: 'Global' },
+  },
+  {
+    name: 'Emergency Water Purification Methods',
+    description:
+      'When clean water is unavailable: Boiling is the safest method - bring water to a rolling boil for 1 minute (3 minutes above 6,500 feet elevation). Chemical disinfection: add 2 drops of unscented household bleach per liter of water, stir and let stand 30 minutes. Solar disinfection (SODIS): fill clear PET bottles and place in direct sunlight for 6+ hours. Always filter cloudy water through cloth first.',
+    resourceType: 'SURVIVAL',
+    coordinates: [0, 0],
+    address: { city: 'Global', country: 'Global' },
+  },
+
+  // --- FIRST_AID entries ---
+  {
+    name: 'First Aid: Crush Injuries and Trapped Victims',
+    description:
+      'For crush injuries after building collapse: Do NOT immediately remove heavy objects from limbs trapped for more than 1 hour - this can cause crush syndrome. Call emergency services first. Keep the victim calm and warm. If the limb is accessible, apply a tourniquet BEFORE releasing the crushing weight. Monitor for signs of shock: pale skin, rapid pulse, confusion. Provide water if conscious and not vomiting.',
+    resourceType: 'FIRST_AID',
+    coordinates: [0, 0],
+    address: { city: 'Global', country: 'Global' },
+  },
+  {
+    name: 'First Aid: Burns and Smoke Inhalation',
+    description:
+      'For burns: Cool the burn immediately with cool (not cold) running water for at least 20 minutes. Do NOT apply ice, butter, or toothpaste. Cover with a clean, non-stick dressing. For smoke inhalation: move victim to fresh air immediately. If not breathing, begin CPR. Watch for delayed symptoms: coughing, hoarseness, or difficulty breathing may develop hours later. Seek medical attention for all burns larger than the palm.',
+    resourceType: 'FIRST_AID',
+    coordinates: [0, 0],
+    address: { city: 'Global', country: 'Global' },
+  },
+];
+
+async function resourceExists(name: string): Promise<boolean> {
+  const existing = await prisma.resource.findFirst({ where: { name } });
+  return existing !== null;
+}
+
+export async function seedResources(systemUser: User): Promise<void> {
+  console.log('--- Seeding Resources ---');
+  let created = 0;
+
+  for (const entry of SEED_RESOURCES) {
+    if (await resourceExists(entry.name)) {
+      console.log(`  Skipping "${entry.name}" - already exists`);
+      continue;
+    }
+
+    // Build the payload matching ValidatedResourcePayload shape
+    const payload = {
+      description: entry.description,
+      resourceType: entry.resourceType,
+      location: {
+        type: 'Point' as const,
+        coordinates: entry.coordinates,
+      },
+      address: entry.address,
+    };
+
+    try {
+      await createResource(payload as any, entry.name, systemUser);
+      created++;
+      console.log(`  Created ${entry.resourceType}: "${entry.name}"`);
+    } catch (error) {
+      console.error(`  Failed to create resource "${entry.name}":`, error);
+    }
+  }
+
+  console.log(`  Created ${created} resources\n`);
+}

--- a/src/services/commentReplies/commentReplies.ts
+++ b/src/services/commentReplies/commentReplies.ts
@@ -5,6 +5,7 @@ import { User } from '@prisma/client';
 import { Collection, ObjectId } from 'mongodb';
 import { DISASTER_COLLECTION_NAME } from '../disasterReports/disasterReports';
 import { deleteFromSupabase } from './upload';
+import * as userService from '@/services/user/user';
 
 export interface ValidatedCommentReplyPayload {
   post_id: string;
@@ -19,23 +20,36 @@ export async function createCommentReply(
   payload: ValidatedCommentReplyPayload,
   user: User,
 ) {
+  const requestingUserId = user.id;
+
   try {
+    const userDetails = await userService.details(requestingUserId);
+
+    if (!userDetails) {
+      throw new NotFoundError('User not found for this comment reply');
+    }
+
     const db = await getMongoDB();
     const commentReplyCollection: Collection = db.collection(
       COMMENT_REPLY_COLLECTION_NAME,
     );
 
-    const userId = user.id;
+    const now = new Date();
 
     const mongoCommentReplyDocument = {
-      userId: userId,
+      user: {
+        id: userDetails.id,
+        firstName: userDetails.firstName,
+        lastName: userDetails.lastName,
+        profile_image: userDetails.profile_image || null,
+      },
       postId: payload.post_id,
       commentId: payload.comment_id,
       reply: payload.reply,
       media: payload.media,
-      commentReplyTimestamp: new Date(),
-      systemCreatedAt: new Date(),
-      systemUpdatedAt: new Date(),
+      commentReplyTimestamp: now,
+      systemCreatedAt: now,
+      systemUpdatedAt: now,
     };
 
     const result = await commentReplyCollection.insertOne(
@@ -46,29 +60,46 @@ export async function createCommentReply(
       throw new InternalServerError('Error creating comment reply in mongoDB');
     }
 
-    return {
-      message: `Comment reply for post ID of ${payload.post_id} and comment ID of ${payload.comment_id} created successfully`,
-    };
+    return result;
   } catch (error) {
     logger.error(`Error creating comment reply: ${error}`);
     throw error;
   }
 }
 
-export async function getCommentReplies(commentId: string) {
+export async function getCommentReplies(
+  commentId: string,
+  limit: number,
+  skip: number,
+) {
   try {
     const db = await getMongoDB();
     const commentReplyCollection: Collection = db.collection(
       COMMENT_REPLY_COLLECTION_NAME,
     );
 
-    const result = await commentReplyCollection
+    const totalCount = await commentReplyCollection.countDocuments({
+      commentId: commentId,
+    });
+
+    const replies = await commentReplyCollection
       .find({
         commentId: commentId,
       })
+      .sort({ systemCreatedAt: -1 })
+      .skip(skip)
+      .limit(limit)
       .toArray();
 
-    return result;
+    return {
+      replies,
+      pagination: {
+        total: totalCount,
+        limit,
+        skip,
+        hasMore: skip + replies.length < totalCount,
+      },
+    };
   } catch (error) {
     logger.error(`Error getting comment replies: ${error}`);
     throw error;

--- a/src/services/comments/comments.ts
+++ b/src/services/comments/comments.ts
@@ -278,6 +278,9 @@ export async function getCommentsByPostId(
     const commentCollection: Collection = db.collection(
       COMMENT_COLLECTION_NAME,
     );
+    const commentReplyCollection: Collection = db.collection(
+      COMMENT_REPLY_COLLECTION_NAME,
+    );
 
     const totalCount = await commentCollection.countDocuments({ postId });
 
@@ -288,8 +291,17 @@ export async function getCommentsByPostId(
       .limit(limit)
       .toArray();
 
+    const commentsWithReplyCount = await Promise.all(
+      comments.map(async (comment) => {
+        const replyCount = await commentReplyCollection.countDocuments({
+          commentId: comment._id.toString(),
+        });
+        return { ...comment, replyCount };
+      }),
+    );
+
     return {
-      comments,
+      comments: commentsWithReplyCount,
       pagination: {
         total: totalCount,
         limit,


### PR DESCRIPTION
Brings `main` up to date with `dev`.

## What's included
Two commits on top of what `main` already has:
- `bc346d3` feat: auto-reporter cron job & system bot
- `7be4a4c` fix: minor fix in auto-reporter worker

## Changes
11 files, +1049 / -16:
- **New:** `src/jobs/usgsAutoReporter.ts` — USGS auto-reporter worker with Redis-backed dedup
- **New:** seed modules (`seedDisasterReports`, `seedActivityPosts`, `seedResources`) and `prisma/seed.ts`
- **Updated:** `src/env.ts` — system bot config vars
- **Updated:** comment/commentReplies services and controllers

## Merge safety
- No merge conflicts (verified with `git merge-tree`)
- `dev` is a content superset of `main` — the diff between the two branch tips is identical to the diff since the merge base, so nothing on `main` gets reverted
- No files deleted by this merge

## Verification
Full stack was run locally against Postgres, MongoDB, RabbitMQ, and Redis: migrations applied, seed completed, and the fact-check round trip (backend → Go service → backend) wrote results back to both databases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Auto-reporter writes real disaster reports and triggers RabbitMQ fact-check flows in production; default system-bot password in env is a credential risk if not overridden. Comment reply create switched to `user` object while update/delete still use `userId`, which can break ownership checks for new replies.
> 
> **Overview**
> Adds a **USGS auto-reporter** worker (`dev:auto-reporter`) that polls M4.5+ earthquakes every 10 minutes, deduplicates events in Redis for 7 days, reverse-geocodes via Nominatim, and creates disaster reports through `createDisasterReport` as a configurable **system bot** user (`ENV` adds bot email/password/username/name defaults).
> 
> Introduces an **idempotent Prisma seed** (`prisma/seed.ts` with `tsconfig-paths`): connects Mongo/RabbitMQ, upserts the bot user, then seeds reports from ReliefWeb + NASA EONET, nearby activity REQUEST/OFFER posts, and static emergency resources.
> 
> **Comment/reply API changes:** new replies embed a denormalized `user` profile (replacing bare `userId` on create); listing replies supports `limit`/`skip` with pagination metadata; post comments now include **`replyCount`** per comment. User profile updates accept **`birthday` via `coerce.date()`** for string payloads.
> 
> **Note:** `updateCommentReply` / `deleteCommentReply` still authorize and `$set` on `userId`, which may not align with new documents that only store `user.id`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7be4a4c58166756bfb73294f86a97998ca60f145. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automatic monitoring and creation of significant earthquake disaster reports.
  - Added initial emergency resources, activity posts, and disaster reports for populated environments.
  - Added pagination metadata and controls for comment replies.
  - Comments now display the number of replies.

- **Bug Fixes**
  - Improved birthday input handling by accepting convertible date values.
  - Comment replies now include validated author details and consistent timestamps.
  - Improved duplicate prevention and error handling during data setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->