### PR TITLE
feat(auth): Bearer token support for mobile clients, plus two auth bugfixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "echo \"Success: no test specified\" && exit 0",
+    "test": "vitest run",
     "build": "tsc --build --listEmittedFiles && tsc-alias && echo \"Success: build completed\"",
     "dev": "pnpm install && pnpm prisma:prepare && pnpm start:dev",
     "prisma:generate": "pnpm prisma generate",
@@ -83,7 +83,8 @@
     "tsc-alias": "^1.8.10",
     "tsconfig-paths": "^4.2.0",
     "typescript": "^5.5.4",
-    "typescript-eslint": "^8.0.0"
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^4.1.10"
   },
   "prisma": {
     "seed": "ts-node -r tsconfig-paths/register ./prisma/seed.ts"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -25,13 +25,13 @@ importers:
         version: 0.10.9
       axios:
         specifier: ^1.7.3
-        version: 1.12.2
+        version: 1.12.2(debug@4.4.3(supports-color@5.5.0))
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
       compression:
         specifier: ^1.7.4
-        version: 1.8.1
+        version: 1.8.1(supports-color@5.5.0)
       cookie-parser:
         specifier: ^1.4.6
         version: 1.4.7
@@ -40,7 +40,7 @@ importers:
         version: 2.8.5
       express:
         specifier: ^4.21.1
-        version: 4.21.2
+        version: 4.21.2(supports-color@5.5.0)
       express-fileupload:
         specifier: ^1.5.1
         version: 1.5.2
@@ -58,7 +58,7 @@ importers:
         version: 6.20.0
       morgan:
         specifier: ^1.10.0
-        version: 1.10.1
+        version: 1.10.1(supports-color@5.5.0)
       multer:
         specifier: ^1.4.5-lts.1
         version: 1.4.5-lts.2
@@ -79,7 +79,7 @@ importers:
         version: 0.34.4
       socket.io:
         specifier: ^4.8.1
-        version: 4.8.1
+        version: 4.8.1(supports-color@5.5.0)
       uuid:
         specifier: ^11.1.0
         version: 11.1.0
@@ -98,7 +98,7 @@ importers:
         version: 9.37.0
       '@trivago/prettier-plugin-sort-imports':
         specifier: ^4.3.0
-        version: 4.3.0(prettier@3.6.2)
+        version: 4.3.0(prettier@3.6.2)(supports-color@5.5.0)
       '@types/amqplib':
         specifier: ^0.10.7
         version: 0.10.7
@@ -140,10 +140,10 @@ importers:
         version: 10.0.0
       eslint:
         specifier: 9.x
-        version: 9.37.0(jiti@2.6.1)
+        version: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       eslint-config-prettier:
         specifier: ^9.1.0
-        version: 9.1.2(eslint@9.37.0(jiti@2.6.1))
+        version: 9.1.2(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))
       globals:
         specifier: ^15.8.0
         version: 15.15.0
@@ -152,7 +152,7 @@ importers:
         version: 9.1.7
       lint-staged:
         specifier: ^15.2.7
-        version: 15.5.2
+        version: 15.5.2(supports-color@5.5.0)
       nodemon:
         specifier: ^3.1.4
         version: 3.1.10
@@ -176,7 +176,10 @@ importers:
         version: 5.9.3
       typescript-eslint:
         specifier: ^8.0.0
-        version: 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+        version: 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      vitest:
+        specifier: ^4.1.10
+        version: 4.1.10(@types/node@22.18.10)(vite@8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1))
 
 packages:
 
@@ -448,78 +451,92 @@ packages:
     resolution: {integrity: sha512-I4RxkXU90cpufazhGPyVujYwfIm9Nk1QDEmiIsaPwdnm013F7RIceaCc87kAH+oUB1ezqEvC6ga4m7MSlqsJvQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.3':
     resolution: {integrity: sha512-x1uE93lyP6wEwGvgAIV0gP6zmaL/a0tGzJs/BIDDG0zeBhMnuUPm7ptxGhUbcGs4okDJrk4nxgrmxpib9g6HpA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.3':
     resolution: {integrity: sha512-Y2T7IsQvJLMCBM+pmPbM3bKT/yYJvVtLJGfCs4Sp95SjvnFIjynbjzsa7dY1fRJX45FTSfDksbTp6AGWudiyCg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.3':
     resolution: {integrity: sha512-RgWrs/gVU7f+K7P+KeHFaBAJlNkD1nIZuVXdQv6S+fNA6syCcoboNjsV2Pou7zNlVdNQoQUpQTk8SWDHUA3y/w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.3':
     resolution: {integrity: sha512-3JU7LmR85K6bBiRzSUc/Ff9JBVIFVvq6bomKE0e63UXGeRw2HPVEjoJke1Yx+iU4rL7/7kUjES4dZ/81Qjhyxg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.3':
     resolution: {integrity: sha512-F9q83RZ8yaCwENw1GieztSfj5msz7GGykG/BA+MOUefvER69K/ubgFHNeSyUu64amHIYKGDs4sRCMzXVj8sEyw==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.3':
     resolution: {integrity: sha512-U5PUY5jbc45ANM6tSJpsgqmBF/VsL6LnxJmIf11kB7J5DctHgqm0SkuXzVWtIY90GnJxKnC/JT251TDnk1fu/g==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.4':
     resolution: {integrity: sha512-YXU1F/mN/Wu786tl72CyJjP/Ngl8mGHN1hST4BGl+hiW5jhCnV2uRVTNOcaYPs73NeT/H8Upm3y9582JVuZHrQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.4':
     resolution: {integrity: sha512-Xyam4mlqM0KkTHYVSuc6wXRmM7LGN0P12li03jAnZ3EJWZqj83+hi8Y9UxZUbxsgsK1qOEwg7O0Bc0LjqQVtxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.4':
     resolution: {integrity: sha512-F4PDtF4Cy8L8hXA2p3TO6s4aDt93v+LKmpcYFLAVdkkD3hSxZzee0rh6/+94FpAynsuMpLX5h+LRsSG3rIciUQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.4':
     resolution: {integrity: sha512-qVrZKE9Bsnzy+myf7lFKvng6bQzhNUAYcVORq2P7bDlvmF6u2sCmK2KyEQEBdYk+u3T01pVsPrkj943T1aJAsw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.4':
     resolution: {integrity: sha512-ZfGtcp2xS51iG79c6Vhw9CWqQC8l2Ot8dygxoDoIQPTat/Ov3qAa8qpxSrtAEAJW+UjTXc4yxCjNfxm4h6Xm2A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.4':
     resolution: {integrity: sha512-8hDVvW9eu4yHWnjaOOR8kHVrew1iIX+MUgwxSuH2XyYeNRtLUe4VNioSqbNkB7ZYQJj9rUTT4PyRscyk2PXFKA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.4':
     resolution: {integrity: sha512-lU0aA5L8QTlfKjpDCEFOZsTYGn3AEiO6db8W5aQDxj0nQkVrZWmN3ZP9sYKWJdtq3PWPhUNlqehWyXpYDcI9Sg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.34.4':
     resolution: {integrity: sha512-33QL6ZO/qpRyG7woB/HUALz28WnTMI2W1jgX3Nu2bypqLIKx/QKMILLJzJjI+SIbvXdG9fUnmrxR7vbi1sTBeA==}
@@ -587,6 +604,9 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-project/types@0.143.0':
+    resolution: {integrity: sha512-u6JZdLBTLotrNC9Vd6vPssINdzcCzleKAH6EJKImQb7GtYvX5keN2dxkoK44stCc4tffE6QQRtZTXVSzsLUlWA==}
+
   '@prisma/client@6.17.1':
     resolution: {integrity: sha512-zL58jbLzYamjnNnmNA51IOZdbk5ci03KviXCuB0Tydc9btH2kDWsi1pQm2VecviRTM7jGia0OPPkgpGnT3nKvw==}
     engines: {node: '>=18.18'}
@@ -644,6 +664,99 @@ packages:
     engines: {node: '>= 18'}
     peerDependencies:
       '@redis/client': ^5.8.3
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    resolution: {integrity: sha512-zrJtHDcaZJ1Fp7xf4hNl+7seH9Cn/N5TwLYkhgXREtBwAd/jaqW3uqeHxpDugJLVICWg4eW44kOQEGJ1r6jCGw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    resolution: {integrity: sha512-ieIiibVCp0tX7TLu2cafoNPv8wJyYi01ekXpbf8q2j7F4rGAhhXb/eQh7ge9DRBY78GwmRQtvjZDux7EDbA8kA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    resolution: {integrity: sha512-Zh9tCon19eDXJoihx0rqKhMUlMYqzwj3aPsSuHmI4RWZh62dWUL+DJN4C5YQya5TcQBJU/Fe8+rY0jhXTQITqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    resolution: {integrity: sha512-nGbJWewA1wrXXZiQhjAT5rhibGfns5ZNkDVqxsO6zJ3f3YvpoDNNmGMSbbhLuXKjNScaBJVOAboztAWVespQMg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    resolution: {integrity: sha512-QNniJr5Kml0kDEB98jiDOJjXNroxIIi0IXIbdYzY26Xt1pVbeP62+KnoIZLwirOymX/0jDk/2gI/bNUv7A7OIw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    resolution: {integrity: sha512-TkqEAcmmvH3I/q4114NB4RVt6241Dao48pF45uLcFGrwAaIn0iITgTAKP/dLjbN0R4buJjGb91+UHSoFmpgIWw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    resolution: {integrity: sha512-NHqjnxpsndf4MPymxteFAWHHfkTL8HjWh1KB7z23ofZ6QO2euONuxDXjat69dKZRALnGypg8k8SsK8vZJoXv1Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    resolution: {integrity: sha512-6tbrbwfz5GB9DQ4Jwo6hy9v+vR31xZlvzZ6n5Xut6Hhx5PvrA9q/HsK8KMaYQp063iqZGXwNvZtYNLD7EM/x0w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    resolution: {integrity: sha512-oyuXxXmoZHjXC917IAPFAAv4wWAa0cM9afk8nx1+9/jNNOX1uPf8yDA6p7G0RypOfw/X0PQt5IfoquY1um+zSg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    resolution: {integrity: sha512-TytMwF2KVGqP2tgd0I1OY0PAv78dZRAYcF5ssDzjM34SUXCED3uXvSd5+lHoC0bTD6eEdFz7LdQNCO1y0oVk9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    resolution: {integrity: sha512-/E9m3qstrJFVPoULV25mVQblSNExY2+kBsYe4sy0Tn0yOOgJ8wZbZt3KnRbF/XeU2Gl1STKUQnDNTqhIE5MD4A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    resolution: {integrity: sha512-Kr0OcsoQI816i6HOl3vFHpd1K0eZyh76zgfj4c1nTyaTsd5r2Mj1lwM4R90y/qaCfmTn9eHy0SKwi98eitRxug==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    resolution: {integrity: sha512-hOtMwTqnME+/gJcH/PCZ0wn0zPUjiWOgkHpxbSJpfGKMezHltx1S7/k1SitzVa7Ww2cqrDDaFbZEhcJZO8o+Jw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    resolution: {integrity: sha512-ekcqMMkI2PlhYnfzQnB/cEdYUVVJViWvoUyLrbzgDoi3Snfc1mVBwdnc306ufA5ejy8JSPjT2RlW1nQSjW7efg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
 
   '@smithy/abort-controller@4.2.0':
     resolution: {integrity: sha512-PLUYa+SUKOEZtXFURBu/CNxlsxfaFGxSBPcStL13KpVeVWIfdezWyDqkz7iDLmwnxojXD0s5KzuB5HGHvt4Aeg==}
@@ -830,6 +943,9 @@ packages:
   '@standard-schema/spec@1.0.0':
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@supabase/auth-js@2.75.0':
     resolution: {integrity: sha512-J8TkeqCOMCV4KwGKVoxmEBuDdHRwoInML2vJilthOo7awVCro2SM+tOcpljORwuBQ1vHUtV62Leit+5wlxrNtw==}
 
@@ -885,6 +1001,9 @@ packages:
   '@types/busboy@1.5.4':
     resolution: {integrity: sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==}
 
+  '@types/chai@5.2.3':
+    resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
+
   '@types/compression@1.8.1':
     resolution: {integrity: sha512-kCFuWS0ebDbmxs0AXYn6e2r2nrGAb5KwQhknjSPSPgJcGd8+HVSILlUyFhGqML2gk39HcG7D1ydW9/qpYkN00Q==}
 
@@ -898,6 +1017,9 @@ packages:
 
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
+  '@types/deep-eql@4.0.2':
+    resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
@@ -1039,6 +1161,35 @@ packages:
     resolution: {integrity: sha512-FrvMpAK+hTbFy7vH5j1+tMYHMSKLE6RzluFJlkFNKD0p9YsUT75JlBSmr5so3QRzvMwU5/bIEdeNrxm8du8l3Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@vitest/expect@4.1.10':
+    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
+
+  '@vitest/mocker@4.1.10':
+    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@4.1.10':
+    resolution: {integrity: sha512-W1HsjSH4MXQ9YfmmhLAoIYf1HRfekQCGngeIgcei6MP5QQGWUe0gkopdZQaVCFO+JDJMrAJGwa5pRpNpvy4P8Q==}
+
+  '@vitest/runner@4.1.10':
+    resolution: {integrity: sha512-IKI6kpIH+LmpROplyLwBBaCfMgOZOMsygVa6BARD6ahA04VRuJSa6OaVG7kRvSEMD870Vd91rSSw0eegtWyLGg==}
+
+  '@vitest/snapshot@4.1.10':
+    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
+
+  '@vitest/spy@4.1.10':
+    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
+
+  '@vitest/utils@4.1.10':
+    resolution: {integrity: sha512-fy9am/HWxbaGt/Sawrp90vt6Y6jQwf1RX77cz3uwoJwJVMli/e1IEwRPnMNJ7vKfPTwo0diXifkpPvwH9v7nGA==}
+
   accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -1103,6 +1254,10 @@ packages:
   array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
 
   async@3.2.6:
     resolution: {integrity: sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==}
@@ -1188,6 +1343,10 @@ packages:
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
+    engines: {node: '>=18'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -1287,6 +1446,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  convert-source-map@2.0.0:
+    resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
   cookie-parser@1.4.7:
     resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
@@ -1444,6 +1606,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@2.3.1:
+    resolution: {integrity: sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -1503,6 +1668,9 @@ packages:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
 
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
   esutils@2.0.3:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
@@ -1517,6 +1685,10 @@ packages:
   execa@8.0.1:
     resolution: {integrity: sha512-VyhnebXciFV2DESc+p6B+y0LjSm0krU4OgJN44qFAhBY0TJ+1V61tYD2+wHusZ6F9n5K+vl8k0sTy7PEfV4qpg==}
     engines: {node: '>=16.17'}
+
+  expect-type@1.4.0:
+    resolution: {integrity: sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==}
+    engines: {node: '>=12.0.0'}
 
   express-fileupload@1.5.2:
     resolution: {integrity: sha512-wxUJn2vTHvj/kZCVmc5/bJO15C7aSMyHeuXYY3geKpeKibaAoQGcEv5+sM6nHS2T7VF+QHS4hTWPiY2mKofEdg==}
@@ -1559,6 +1731,15 @@ packages:
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
 
   fecha@4.2.3:
     resolution: {integrity: sha512-OP2IUU6HeYKJi3i0z4A19kHMQoLVs4Hc+DPqqxI2h/DPZHTm/vjsfC6P0b4jCMy14XizLBqvndQ+UilD7707Jw==}
@@ -1659,6 +1840,7 @@ packages:
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   globals@11.12.0:
@@ -1863,6 +2045,80 @@ packages:
     resolution: {integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==}
     engines: {node: '>= 0.8.0'}
 
+  lightningcss-android-arm64@1.33.0:
+    resolution: {integrity: sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.33.0:
+    resolution: {integrity: sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.33.0:
+    resolution: {integrity: sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.33.0:
+    resolution: {integrity: sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    resolution: {integrity: sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    resolution: {integrity: sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    resolution: {integrity: sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    resolution: {integrity: sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.33.0:
+    resolution: {integrity: sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    resolution: {integrity: sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    resolution: {integrity: sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.33.0:
+    resolution: {integrity: sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA==}
+    engines: {node: '>= 12.0.0'}
+
   lilconfig@3.1.3:
     resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
     engines: {node: '>=14'}
@@ -1918,6 +2174,9 @@ packages:
   lru-cache@11.2.2:
     resolution: {integrity: sha512-F9ODfyqML2coTIsQpSkRHnLSZMtkU8Q+mSfcaIyKwy58u+8k5nvAYeiNhsyMARvzNcXJ9QfWVrcPsC9e9rAxtg==}
     engines: {node: 20 || >=22}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
   make-error@1.3.6:
     resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
@@ -2050,6 +2309,11 @@ packages:
     resolution: {integrity: sha512-+MrqnJRtxdF+xngFfUUkIMQrUUL0KsxbADUkn23Z/4ibGg192Q+z+CQyiYwvWTsYjJygmMR8+w3ZDa98Zh6ESg==}
     engines: {node: '>=12.0.0'}
 
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
 
@@ -2111,6 +2375,10 @@ packages:
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
+
+  obug@2.1.4:
+    resolution: {integrity: sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA==}
+    engines: {node: '>=12.20.0'}
 
   ohash@2.0.11:
     resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
@@ -2197,6 +2465,10 @@ packages:
     resolution: {integrity: sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==}
     engines: {node: '>=8.6'}
 
+  picomatch@4.0.5:
+    resolution: {integrity: sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==}
+    engines: {node: '>=12'}
+
   pidtree@0.6.0:
     resolution: {integrity: sha512-eG2dWTVw5bzqGRztnHExczNxt5VGsE6OwTeCG3fdUf9KBsZzO3R5OIIIzWR+iZA0NtZ+RDVdaoE2dK1cn6jH4g==}
     engines: {node: '>=0.10'}
@@ -2208,6 +2480,10 @@ packages:
   plimit-lit@1.6.1:
     resolution: {integrity: sha512-B7+VDyb8Tl6oMJT9oSO2CW8XC/T4UcJGrwOVoNGwOQsQYhlpfajmrMj5xeejqaASq3V/EqThyOeATEOMuSEXiA==}
     engines: {node: '>=12'}
+
+  postcss@8.5.26:
+    resolution: {integrity: sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   prelude-ls@1.2.1:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
@@ -2313,6 +2589,11 @@ packages:
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
 
+  rolldown@1.2.3:
+    resolution: {integrity: sha512-rn9wpmxplLf7NLNyCk9FyWh3FM43DbY8jOzCdEPzH7uflhTftRbCEpqi6Ly2osgoU8OwObtmavMbWLaWy4LX7A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2373,6 +2654,9 @@ packages:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
     engines: {node: '>= 0.4'}
 
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
@@ -2404,6 +2688,10 @@ packages:
     resolution: {integrity: sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==}
     engines: {node: '>=10.2.0'}
 
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
   source-map@0.5.7:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
@@ -2418,9 +2706,15 @@ packages:
   stack-trace@0.0.10:
     resolution: {integrity: sha512-KGzahc7puUKkzyMt+IqAep+TVNbKP+k2Lmwhub39m1AsTSkaDutx56aDCo+HLDzf/D26BIHTJWNiTG1KAJiQCg==}
 
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
   statuses@2.0.1:
     resolution: {integrity: sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==}
     engines: {node: '>= 0.8'}
+
+  std-env@4.2.0:
+    resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
@@ -2482,8 +2776,23 @@ packages:
   text-hex@1.0.0:
     resolution: {integrity: sha512-uuVGNWzgJ4yhRaNSiubPY7OjISw4sw4E5Uv0wbjp+OzcbmVU/rsT8ujgcXJhn9ypzsgr5vlzpPqP+MBBKcGvbg==}
 
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
+  tinyexec@1.3.0:
+    resolution: {integrity: sha512-QKAl9m8gWWGHV8jZcPeym6j+XULi6tOf1mT83WYJ4Lk2ytW/uwAWkrP0uFsdoYMdueVJ0qs26wZ+23xeB4ibNQ==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinyrainbow@3.1.1:
+    resolution: {integrity: sha512-yau8yJdTt989Mm0Bd/236QnzEiPf2xLLTqUZRUJOo/3CB078LSwzei343DgtJVmfJKJE3TMINY1u42SQsP6mXw==}
+    engines: {node: '>=14.0.0'}
 
   to-fast-properties@2.0.0:
     resolution: {integrity: sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==}
@@ -2606,6 +2915,90 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  vite@8.2.1:
+    resolution: {integrity: sha512-EU/eS7BH3XROHh2YnBefjM6DBKA6ZeMZEYQbj7NLWg5wHYlhB8B/Mayd5XsgWq+NFYccDOTemRpdETWR6Ka/lw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.4.0
+      esbuild: ^0.27.0 || ^0.28.0
+      jiti: '>=1.21.0'
+      less: ^4.0.0
+      sass: ^1.70.0
+      sass-embedded: ^1.70.0
+      stylus: '>=0.54.8'
+      sugarss: ^5.0.0
+      terser: ^5.16.0
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
+      jiti:
+        optional: true
+      less:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  vitest@4.1.10:
+    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.10
+      '@vitest/browser-preview': 4.1.10
+      '@vitest/browser-webdriverio': 4.1.10
+      '@vitest/coverage-istanbul': 4.1.10
+      '@vitest/coverage-v8': 4.1.10
+      '@vitest/ui': 4.1.10
+      happy-dom: '*'
+      jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@opentelemetry/api':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
+        optional: true
+      '@vitest/coverage-istanbul':
+        optional: true
+      '@vitest/coverage-v8':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
 
@@ -2623,6 +3016,11 @@ packages:
   which@2.0.2:
     resolution: {integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==}
     engines: {node: '>= 8'}
+    hasBin: true
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
     hasBin: true
 
   winston-daily-rotate-file@5.0.0:
@@ -3110,7 +3508,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
 
-  '@babel/traverse@7.23.2':
+  '@babel/traverse@7.23.2(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
       '@babel/generator': 7.28.3
@@ -3152,14 +3550,14 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.1))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))':
     dependencies:
-      eslint: 9.37.0(jiti@2.6.1)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
 
-  '@eslint/config-array@0.21.0':
+  '@eslint/config-array@0.21.0(supports-color@5.5.0)':
     dependencies:
       '@eslint/object-schema': 2.1.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -3175,7 +3573,7 @@ snapshots:
     dependencies:
       '@types/json-schema': 7.0.15
 
-  '@eslint/eslintrc@3.3.1':
+  '@eslint/eslintrc@3.3.1(supports-color@5.5.0)':
     dependencies:
       ajv: 6.12.6
       debug: 4.4.3(supports-color@5.5.0)
@@ -3347,6 +3745,8 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  '@oxc-project/types@0.143.0': {}
+
   '@prisma/client@6.17.1(prisma@6.17.1(typescript@5.9.3))(typescript@5.9.3)':
     optionalDependencies:
       prisma: 6.17.1(typescript@5.9.3)
@@ -3401,6 +3801,50 @@ snapshots:
   '@redis/time-series@5.8.3(@redis/client@5.8.3)':
     dependencies:
       '@redis/client': 5.8.3
+
+  '@rolldown/binding-android-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.2.3':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.2.3':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.2.3':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.1': {}
 
   '@smithy/abort-controller@4.2.0':
     dependencies:
@@ -3690,6 +4134,8 @@ snapshots:
 
   '@standard-schema/spec@1.0.0': {}
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@supabase/auth-js@2.75.0':
     dependencies:
       '@supabase/node-fetch': 2.6.15
@@ -3732,11 +4178,11 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.6.2)':
+  '@trivago/prettier-plugin-sort-imports@4.3.0(prettier@3.6.2)(supports-color@5.5.0)':
     dependencies:
       '@babel/generator': 7.17.7
       '@babel/parser': 7.28.4
-      '@babel/traverse': 7.23.2
+      '@babel/traverse': 7.23.2(supports-color@5.5.0)
       '@babel/types': 7.17.0
       javascript-natural-sort: 0.7.1
       lodash: 4.17.21
@@ -3767,6 +4213,11 @@ snapshots:
     dependencies:
       '@types/node': 22.18.10
 
+  '@types/chai@5.2.3':
+    dependencies:
+      '@types/deep-eql': 4.0.2
+      assertion-error: 2.0.1
+
   '@types/compression@1.8.1':
     dependencies:
       '@types/express': 4.17.23
@@ -3783,6 +4234,8 @@ snapshots:
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 22.18.10
+
+  '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
 
@@ -3883,15 +4336,15 @@ snapshots:
     dependencies:
       '@types/node': 22.18.10
 
-  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 8.46.0
-      '@typescript-eslint/type-utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/type-utils': 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.0
-      eslint: 9.37.0(jiti@2.6.1)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -3900,19 +4353,19 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.0
       '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.0(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.46.0
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.37.0(jiti@2.6.1)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/project-service@8.46.0(typescript@5.9.3)':
+  '@typescript-eslint/project-service@8.46.0(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.0
@@ -3930,13 +4383,13 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
-  '@typescript-eslint/type-utils@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/type-utils@8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.0(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
       debug: 4.4.3(supports-color@5.5.0)
-      eslint: 9.37.0(jiti@2.6.1)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       ts-api-utils: 2.1.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -3944,9 +4397,9 @@ snapshots:
 
   '@typescript-eslint/types@8.46.0': {}
 
-  '@typescript-eslint/typescript-estree@8.46.0(typescript@5.9.3)':
+  '@typescript-eslint/typescript-estree@8.46.0(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@typescript-eslint/project-service': 8.46.0(typescript@5.9.3)
+      '@typescript-eslint/project-service': 8.46.0(supports-color@5.5.0)(typescript@5.9.3)
       '@typescript-eslint/tsconfig-utils': 8.46.0(typescript@5.9.3)
       '@typescript-eslint/types': 8.46.0
       '@typescript-eslint/visitor-keys': 8.46.0
@@ -3960,13 +4413,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))
       '@typescript-eslint/scope-manager': 8.46.0
       '@typescript-eslint/types': 8.46.0
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
-      eslint: 9.37.0(jiti@2.6.1)
+      '@typescript-eslint/typescript-estree': 8.46.0(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -3975,6 +4428,47 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.46.0
       eslint-visitor-keys: 4.2.1
+
+  '@vitest/expect@4.1.10':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.3
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      chai: 6.2.2
+      tinyrainbow: 3.1.1
+
+  '@vitest/mocker@4.1.10(vite@8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1))':
+    dependencies:
+      '@vitest/spy': 4.1.10
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1)
+
+  '@vitest/pretty-format@4.1.10':
+    dependencies:
+      tinyrainbow: 3.1.1
+
+  '@vitest/runner@4.1.10':
+    dependencies:
+      '@vitest/utils': 4.1.10
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/utils': 4.1.10
+      magic-string: 0.30.21
+      pathe: 2.0.3
+
+  '@vitest/spy@4.1.10': {}
+
+  '@vitest/utils@4.1.10':
+    dependencies:
+      '@vitest/pretty-format': 4.1.10
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.1
 
   accepts@1.3.8:
     dependencies:
@@ -4032,13 +4526,15 @@ snapshots:
 
   array-union@2.1.0: {}
 
+  assertion-error@2.0.1: {}
+
   async@3.2.6: {}
 
   asynckit@0.4.0: {}
 
-  axios@1.12.2:
+  axios@1.12.2(debug@4.4.3(supports-color@5.5.0)):
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.15.11(debug@4.4.3(supports-color@5.5.0))
       form-data: 4.0.4
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -4056,11 +4552,11 @@ snapshots:
 
   binary-extensions@2.3.0: {}
 
-  body-parser@1.20.3:
+  body-parser@1.20.3(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       depd: 2.0.0
       destroy: 1.2.0
       http-errors: 2.0.0
@@ -4128,6 +4624,8 @@ snapshots:
       get-intrinsic: 1.3.0
 
   callsites@3.1.0: {}
+
+  chai@6.2.2: {}
 
   chalk@4.1.2:
     dependencies:
@@ -4202,11 +4700,11 @@ snapshots:
     dependencies:
       mime-db: 1.54.0
 
-  compression@1.8.1:
+  compression@1.8.1(supports-color@5.5.0):
     dependencies:
       bytes: 3.1.2
       compressible: 2.0.18
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       negotiator: 0.6.4
       on-headers: 1.1.0
       safe-buffer: 5.2.1
@@ -4232,6 +4730,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
+
+  convert-source-map@2.0.0: {}
 
   cookie-parser@1.4.7:
     dependencies:
@@ -4259,13 +4759,17 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
-  debug@2.6.9:
+  debug@2.6.9(supports-color@5.5.0):
     dependencies:
       ms: 2.0.0
+    optionalDependencies:
+      supports-color: 5.5.0
 
-  debug@4.3.7:
+  debug@4.3.7(supports-color@5.5.0):
     dependencies:
       ms: 2.1.3
+    optionalDependencies:
+      supports-color: 5.5.0
 
   debug@4.4.3(supports-color@5.5.0):
     dependencies:
@@ -4332,7 +4836,7 @@ snapshots:
 
   engine.io-parser@5.2.3: {}
 
-  engine.io@6.6.4:
+  engine.io@6.6.4(supports-color@5.5.0):
     dependencies:
       '@types/cors': 2.8.19
       '@types/node': 22.18.10
@@ -4340,7 +4844,7 @@ snapshots:
       base64id: 2.0.0
       cookie: 0.7.2
       cors: 2.8.5
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       engine.io-parser: 5.2.3
       ws: 8.17.1
     transitivePeerDependencies:
@@ -4353,6 +4857,8 @@ snapshots:
   es-define-property@1.0.1: {}
 
   es-errors@1.3.0: {}
+
+  es-module-lexer@2.3.1: {}
 
   es-object-atoms@1.1.1:
     dependencies:
@@ -4369,9 +4875,9 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-prettier@9.1.2(eslint@9.37.0(jiti@2.6.1)):
+  eslint-config-prettier@9.1.2(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0)):
     dependencies:
-      eslint: 9.37.0(jiti@2.6.1)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
 
   eslint-scope@8.4.0:
     dependencies:
@@ -4382,14 +4888,14 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.37.0(jiti@2.6.1):
+  eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0):
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))
       '@eslint-community/regexpp': 4.12.1
-      '@eslint/config-array': 0.21.0
+      '@eslint/config-array': 0.21.0(supports-color@5.5.0)
       '@eslint/config-helpers': 0.4.0
       '@eslint/core': 0.16.0
-      '@eslint/eslintrc': 3.3.1
+      '@eslint/eslintrc': 3.3.1(supports-color@5.5.0)
       '@eslint/js': 9.37.0
       '@eslint/plugin-kit': 0.4.0
       '@humanfs/node': 0.16.7
@@ -4440,6 +4946,10 @@ snapshots:
 
   estraverse@5.3.0: {}
 
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.8
+
   esutils@2.0.3: {}
 
   etag@1.8.1: {}
@@ -4458,6 +4968,8 @@ snapshots:
       signal-exit: 4.1.0
       strip-final-newline: 3.0.0
 
+  expect-type@1.4.0: {}
+
   express-fileupload@1.5.2:
     dependencies:
       busboy: 1.6.0
@@ -4470,21 +4982,21 @@ snapshots:
 
   express-list-routes@1.3.1: {}
 
-  express@4.21.2:
+  express@4.21.2(supports-color@5.5.0):
     dependencies:
       accepts: 1.3.8
       array-flatten: 1.1.1
-      body-parser: 1.20.3
+      body-parser: 1.20.3(supports-color@5.5.0)
       content-disposition: 0.5.4
       content-type: 1.0.5
       cookie: 0.7.1
       cookie-signature: 1.0.6
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
-      finalhandler: 1.3.1
+      finalhandler: 1.3.1(supports-color@5.5.0)
       fresh: 0.5.2
       http-errors: 2.0.0
       merge-descriptors: 1.0.3
@@ -4496,8 +5008,8 @@ snapshots:
       qs: 6.13.0
       range-parser: 1.2.1
       safe-buffer: 5.2.1
-      send: 0.19.0
-      serve-static: 1.16.2
+      send: 0.19.0(supports-color@5.5.0)
+      serve-static: 1.16.2(supports-color@5.5.0)
       setprototypeof: 1.2.0
       statuses: 2.0.1
       type-is: 1.6.18
@@ -4534,6 +5046,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fdir@6.5.0(picomatch@4.0.5):
+    optionalDependencies:
+      picomatch: 4.0.5
+
   fecha@4.2.3: {}
 
   file-entry-cache@8.0.0:
@@ -4548,9 +5064,9 @@ snapshots:
     dependencies:
       to-regex-range: 5.0.1
 
-  finalhandler@1.3.1:
+  finalhandler@1.3.1(supports-color@5.5.0):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -4574,7 +5090,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.15.11(debug@4.4.3(supports-color@5.5.0)):
+    optionalDependencies:
+      debug: 4.4.3(supports-color@5.5.0)
 
   foreground-child@3.3.1:
     dependencies:
@@ -4818,9 +5336,58 @@ snapshots:
       prelude-ls: 1.2.1
       type-check: 0.4.0
 
+  lightningcss-android-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.33.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.33.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.33.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.33.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.33.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.33.0:
+    optional: true
+
+  lightningcss@1.33.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.33.0
+      lightningcss-darwin-arm64: 1.33.0
+      lightningcss-darwin-x64: 1.33.0
+      lightningcss-freebsd-x64: 1.33.0
+      lightningcss-linux-arm-gnueabihf: 1.33.0
+      lightningcss-linux-arm64-gnu: 1.33.0
+      lightningcss-linux-arm64-musl: 1.33.0
+      lightningcss-linux-x64-gnu: 1.33.0
+      lightningcss-linux-x64-musl: 1.33.0
+      lightningcss-win32-arm64-msvc: 1.33.0
+      lightningcss-win32-x64-msvc: 1.33.0
+
   lilconfig@3.1.3: {}
 
-  lint-staged@15.5.2:
+  lint-staged@15.5.2(supports-color@5.5.0):
     dependencies:
       chalk: 5.6.2
       commander: 13.1.0
@@ -4884,6 +5451,10 @@ snapshots:
       triple-beam: 1.4.1
 
   lru-cache@11.2.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
 
   make-error@1.3.6: {}
 
@@ -4953,10 +5524,10 @@ snapshots:
       bson: 6.10.4
       mongodb-connection-string-url: 3.0.2
 
-  morgan@1.10.1:
+  morgan@1.10.1(supports-color@5.5.0):
     dependencies:
       basic-auth: 2.0.1
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       depd: 2.0.0
       on-finished: 2.3.0
       on-headers: 1.1.0
@@ -4978,6 +5549,8 @@ snapshots:
       xtend: 4.0.2
 
   mylas@2.1.13: {}
+
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5030,6 +5603,8 @@ snapshots:
   object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
+
+  obug@2.1.4: {}
 
   ohash@2.0.11: {}
 
@@ -5103,6 +5678,8 @@ snapshots:
 
   picomatch@2.3.1: {}
 
+  picomatch@4.0.5: {}
+
   pidtree@0.6.0: {}
 
   pkg-types@2.3.0:
@@ -5114,6 +5691,12 @@ snapshots:
   plimit-lit@1.6.1:
     dependencies:
       queue-lit: 1.5.2
+
+  postcss@8.5.26:
+    dependencies:
+      nanoid: 3.3.18
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   prelude-ls@1.2.1: {}
 
@@ -5212,6 +5795,26 @@ snapshots:
 
   rfdc@1.4.1: {}
 
+  rolldown@1.2.3:
+    dependencies:
+      '@oxc-project/types': 0.143.0
+      '@rolldown/pluginutils': 1.0.1
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.2.3
+      '@rolldown/binding-darwin-arm64': 1.2.3
+      '@rolldown/binding-darwin-x64': 1.2.3
+      '@rolldown/binding-freebsd-x64': 1.2.3
+      '@rolldown/binding-linux-arm-gnueabihf': 1.2.3
+      '@rolldown/binding-linux-arm64-gnu': 1.2.3
+      '@rolldown/binding-linux-arm64-musl': 1.2.3
+      '@rolldown/binding-linux-ppc64-gnu': 1.2.3
+      '@rolldown/binding-linux-s390x-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-gnu': 1.2.3
+      '@rolldown/binding-linux-x64-musl': 1.2.3
+      '@rolldown/binding-openharmony-arm64': 1.2.3
+      '@rolldown/binding-win32-arm64-msvc': 1.2.3
+      '@rolldown/binding-win32-x64-msvc': 1.2.3
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -5226,9 +5829,9 @@ snapshots:
 
   semver@7.7.3: {}
 
-  send@0.19.0:
+  send@0.19.0(supports-color@5.5.0):
     dependencies:
-      debug: 2.6.9
+      debug: 2.6.9(supports-color@5.5.0)
       depd: 2.0.0
       destroy: 1.2.0
       encodeurl: 1.0.2
@@ -5244,12 +5847,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  serve-static@1.16.2:
+  serve-static@1.16.2(supports-color@5.5.0):
     dependencies:
       encodeurl: 2.0.0
       escape-html: 1.0.3
       parseurl: 1.3.3
-      send: 0.19.0
+      send: 0.19.0(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5318,6 +5921,8 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  siginfo@2.0.0: {}
+
   signal-exit@4.1.0: {}
 
   simple-update-notifier@2.0.0:
@@ -5336,35 +5941,37 @@ snapshots:
       ansi-styles: 6.2.3
       is-fullwidth-code-point: 5.1.0
 
-  socket.io-adapter@2.5.5:
+  socket.io-adapter@2.5.5(supports-color@5.5.0):
     dependencies:
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
       ws: 8.17.1
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
 
-  socket.io-parser@4.2.4:
+  socket.io-parser@4.2.4(supports-color@5.5.0):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.7
+      debug: 4.3.7(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
-  socket.io@4.8.1:
+  socket.io@4.8.1(supports-color@5.5.0):
     dependencies:
       accepts: 1.3.8
       base64id: 2.0.0
       cors: 2.8.5
-      debug: 4.3.7
-      engine.io: 6.6.4
-      socket.io-adapter: 2.5.5
-      socket.io-parser: 4.2.4
+      debug: 4.3.7(supports-color@5.5.0)
+      engine.io: 6.6.4(supports-color@5.5.0)
+      socket.io-adapter: 2.5.5(supports-color@5.5.0)
+      socket.io-parser: 4.2.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
       - utf-8-validate
+
+  source-map-js@1.2.1: {}
 
   source-map@0.5.7: {}
 
@@ -5376,7 +5983,11 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
+  stackback@0.0.2: {}
+
   statuses@2.0.1: {}
+
+  std-env@4.2.0: {}
 
   streamsearch@1.1.0: {}
 
@@ -5434,7 +6045,18 @@ snapshots:
 
   text-hex@1.0.0: {}
 
+  tinybench@2.9.0: {}
+
   tinyexec@1.0.1: {}
+
+  tinyexec@1.3.0: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
+
+  tinyrainbow@3.1.1: {}
 
   to-fast-properties@2.0.0: {}
 
@@ -5505,13 +6127,13 @@ snapshots:
 
   typedarray@0.0.6: {}
 
-  typescript-eslint@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3):
+  typescript-eslint@8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.9.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1))(typescript@5.9.3)
-      eslint: 9.37.0(jiti@2.6.1)
+      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3))(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.46.0(supports-color@5.5.0)(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.37.0(jiti@2.6.1)(supports-color@5.5.0))(supports-color@5.5.0)(typescript@5.9.3)
+      eslint: 9.37.0(jiti@2.6.1)(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -5546,6 +6168,46 @@ snapshots:
 
   vary@1.1.2: {}
 
+  vite@8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1):
+    dependencies:
+      lightningcss: 1.33.0
+      picomatch: 4.0.5
+      postcss: 8.5.26
+      rolldown: 1.2.3
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.18.10
+      fsevents: 2.3.3
+      jiti: 2.6.1
+      yaml: 2.8.1
+
+  vitest@4.1.10(@types/node@22.18.10)(vite@8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1)):
+    dependencies:
+      '@vitest/expect': 4.1.10
+      '@vitest/mocker': 4.1.10(vite@8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1))
+      '@vitest/pretty-format': 4.1.10
+      '@vitest/runner': 4.1.10
+      '@vitest/snapshot': 4.1.10
+      '@vitest/spy': 4.1.10
+      '@vitest/utils': 4.1.10
+      es-module-lexer: 2.3.1
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      obug: 2.1.4
+      pathe: 2.0.3
+      picomatch: 4.0.5
+      std-env: 4.2.0
+      tinybench: 2.9.0
+      tinyexec: 1.3.0
+      tinyglobby: 0.2.17
+      tinyrainbow: 3.1.1
+      vite: 8.2.1(@types/node@22.18.10)(jiti@2.6.1)(yaml@2.8.1)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.18.10
+    transitivePeerDependencies:
+      - msw
+
   webidl-conversions@3.0.1: {}
 
   webidl-conversions@7.0.0: {}
@@ -5563,6 +6225,11 @@ snapshots:
   which@2.0.2:
     dependencies:
       isexe: 2.0.0
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
 
   winston-daily-rotate-file@5.0.0(winston@3.18.3):
     dependencies:

--- a/src/controllers/auth/user.ts
+++ b/src/controllers/auth/user.ts
@@ -99,6 +99,14 @@ const loginUser = async (req: Request, res: Response, next: NextFunction) => {
       secure: true,
     });
 
+    const isMobileClient = req.headers['x-client'] === 'mobile';
+    if (isMobileClient) {
+      return res.status(200).json({
+        ...userInfo,
+        token,
+        refreshToken: refershToken ?? null,
+      });
+    }
     return res.status(200).json(userInfo);
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/controllers/auth/user.ts
+++ b/src/controllers/auth/user.ts
@@ -86,6 +86,16 @@ const loginUser = async (req: Request, res: Response, next: NextFunction) => {
       password,
       rememberMe,
     );
+
+    const isMobileClient = req.headers['x-client'] === 'mobile';
+    if (isMobileClient) {
+      return res.status(200).json({
+        ...userInfo,
+        token,
+        refreshToken: refershToken ?? null,
+      });
+    }
+
     if (refershToken) {
       res.cookie('refreshToken', refershToken, {
         httpOnly: true,
@@ -99,14 +109,6 @@ const loginUser = async (req: Request, res: Response, next: NextFunction) => {
       secure: true,
     });
 
-    const isMobileClient = req.headers['x-client'] === 'mobile';
-    if (isMobileClient) {
-      return res.status(200).json({
-        ...userInfo,
-        token,
-        refreshToken: refershToken ?? null,
-      });
-    }
     return res.status(200).json(userInfo);
   } catch (error) {
     if (error instanceof ZodError) {

--- a/src/controllers/auth/user.ts
+++ b/src/controllers/auth/user.ts
@@ -180,6 +180,23 @@ const resetPassword = async (
   }
 };
 
+const refreshSchema = object({
+  refreshToken: string().min(1),
+});
+
+const refresh = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { refreshToken } = refreshSchema.parse(req.body);
+    const tokens = await userService.refreshUserToken(refreshToken);
+    return res.status(200).json(tokens);
+  } catch (error) {
+    if (error instanceof ZodError) {
+      return next(new ValidationError(error.issues));
+    }
+    return next(error);
+  }
+};
+
 export {
   registerUser,
   loginUser,
@@ -188,4 +205,5 @@ export {
   resendEmail,
   forgotPassword,
   resetPassword,
+  refresh,
 };

--- a/src/middlewares/secure-route.ts
+++ b/src/middlewares/secure-route.ts
@@ -38,7 +38,7 @@ const secureRoute = () => {
     try {
       const decoded = verifyAccessToken(token);
       const result = await prisma.user.findUnique({
-        where: { id: decoded.userId },
+        where: { id: decoded.userId, deleted_at: null },
       });
 
       if (!result) {
@@ -55,7 +55,7 @@ const secureRoute = () => {
         try {
           const decodedRefreshToken = verifyRefreshToken(refreshToken);
           const result = await prisma.user.findUnique({
-            where: { id: decodedRefreshToken.userId },
+            where: { id: decodedRefreshToken.userId, deleted_at: null },
           });
           if (!result) {
             return next(new AuthenticationError('Access denied'));

--- a/src/middlewares/secure-route.ts
+++ b/src/middlewares/secure-route.ts
@@ -1,25 +1,42 @@
-import { ENV } from '@/env';
 import prisma from '@/libs/prisma';
 import logger from '@/logger';
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken,
+} from '@/services/auth/token-service';
 import { AuthenticationError } from '@/utils/errors';
 import { NextFunction, Request, Response } from 'express';
-import jwt, { TokenExpiredError } from 'jsonwebtoken';
+import { TokenExpiredError } from 'jsonwebtoken';
 
-interface JwtPayload {
-  userId: string;
-}
+const COOKIE_OPTIONS = {
+  httpOnly: true,
+  sameSite: 'none',
+  secure: true,
+} as const;
+
+const getBearerToken = (req: Request): string | undefined => {
+  const header = req.headers.authorization;
+  return header?.startsWith('Bearer ')
+    ? header.slice('Bearer '.length)
+    : undefined;
+};
 
 const secureRoute = () => {
   return async (req: Request, res: Response, next: NextFunction) => {
-    const token = req.cookies.token;
-    const refreshToken = req.cookies.refreshToken;
+    const cookieToken = req.cookies.token as string | undefined;
+    const bearerToken = getBearerToken(req);
+    const token = cookieToken ?? bearerToken;
+    const isBearer = !cookieToken && !!bearerToken;
+    const refreshToken = req.cookies.refreshToken as string | undefined;
 
     if (!token) {
       return next(new AuthenticationError('Token is required'));
     }
 
     try {
-      const decoded = jwt.verify(token, ENV.JWT_SECRET) as JwtPayload;
+      const decoded = verifyAccessToken(token);
       const result = await prisma.user.findUnique({
         where: { id: decoded.userId },
       });
@@ -30,12 +47,13 @@ const secureRoute = () => {
       req.user = result;
       return next();
     } catch (error) {
+      if (error instanceof TokenExpiredError && isBearer) {
+        // Bearer clients hold their own refresh token; they must call POST /auth/refresh.
+        return next(new AuthenticationError('Token expired'));
+      }
       if (error instanceof TokenExpiredError && refreshToken) {
         try {
-          const decodedRefreshToken = jwt.verify(
-            refreshToken,
-            ENV.JWT_SECRET,
-          ) as Pick<JwtPayload, 'userId'>;
+          const decodedRefreshToken = verifyRefreshToken(refreshToken);
           const result = await prisma.user.findUnique({
             where: { id: decodedRefreshToken.userId },
           });
@@ -43,29 +61,12 @@ const secureRoute = () => {
             return next(new AuthenticationError('Access denied'));
           }
 
-          const newRefreshToken = jwt.sign(
-            {
-              userId: result.id,
-            },
-            ENV.REFRESH_TOKEN_SECRET,
-            { expiresIn: '30d' },
+          res.cookie(
+            'refreshToken',
+            signRefreshToken(result.id),
+            COOKIE_OPTIONS,
           );
-
-          const newToken = jwt.sign({ userId: result.id }, ENV.JWT_SECRET, {
-            expiresIn: '1d',
-          });
-
-          res.cookie('refreshToken', newRefreshToken, {
-            httpOnly: true,
-            sameSite: 'none',
-            secure: true,
-          });
-
-          res.cookie('token', newToken, {
-            httpOnly: true,
-            sameSite: 'none',
-            secure: true,
-          });
+          res.cookie('token', signAccessToken(result.id), COOKIE_OPTIONS);
           req.user = result;
           return next();
         } catch (refreshError) {
@@ -73,12 +74,11 @@ const secureRoute = () => {
           logger.error('Error verifying refresh token', refreshError);
           return next(new AuthenticationError('Invalid refresh token'));
         }
-      } else {
-        res.clearCookie('token');
-        res.clearCookie('refreshToken');
-        logger.error('Error authenticating user:', error);
-        return next(new AuthenticationError('Invalid token'));
       }
+      res.clearCookie('token');
+      res.clearCookie('refreshToken');
+      logger.error('Error authenticating user:', error);
+      return next(new AuthenticationError('Invalid token'));
     }
   };
 };

--- a/src/routes/auth/auth.ts
+++ b/src/routes/auth/auth.ts
@@ -7,6 +7,7 @@ const router = Router();
 router.get('/', secureRoute(), userController.auth);
 router.post('/register', userController.registerUser);
 router.post('/login', userController.loginUser);
+router.post('/refresh', userController.refresh);
 router.get('/verify-email/:token', userController.verifyEmail);
 router.post('/resend-email', userController.resendEmail);
 router.post('/forgot-password', userController.forgotPassword);

--- a/src/services/auth/token-service.ts
+++ b/src/services/auth/token-service.ts
@@ -1,0 +1,18 @@
+import { ENV } from '@/env';
+import jwt from 'jsonwebtoken';
+
+export interface TokenPayload {
+  userId: string;
+}
+
+export const signAccessToken = (userId: string): string =>
+  jwt.sign({ userId }, ENV.JWT_SECRET, { expiresIn: '1d' });
+
+export const signRefreshToken = (userId: string): string =>
+  jwt.sign({ userId }, ENV.REFRESH_TOKEN_SECRET, { expiresIn: '30d' });
+
+export const verifyAccessToken = (token: string): TokenPayload =>
+  jwt.verify(token, ENV.JWT_SECRET) as TokenPayload;
+
+export const verifyRefreshToken = (token: string): TokenPayload =>
+  jwt.verify(token, ENV.REFRESH_TOKEN_SECRET) as TokenPayload;

--- a/src/services/auth/user.ts
+++ b/src/services/auth/user.ts
@@ -3,6 +3,11 @@ import { sendEmail } from '@/helpers/sendEmail';
 import prisma from '@/libs/prisma';
 import logger from '@/logger';
 import {
+  signAccessToken,
+  signRefreshToken,
+  verifyRefreshToken,
+} from '@/services/auth/token-service';
+import {
   AuthenticationError,
   ConflictError,
   EmailValidationError,
@@ -300,6 +305,26 @@ const resetPassword = async (token: string, password: string) => {
   } catch (error) {
     logger.error('Error reset password', error);
     throw error;
+  }
+};
+
+export const refreshUserToken = async (refreshToken: string) => {
+  try {
+    const decoded = verifyRefreshToken(refreshToken);
+    const result = await prisma.user.findUnique({
+      where: { id: decoded.userId },
+    });
+    if (!result) {
+      throw new AuthenticationError('Access denied');
+    }
+    return {
+      token: signAccessToken(result.id),
+      refreshToken: signRefreshToken(result.id),
+    };
+  } catch (error) {
+    logger.error('Error refreshing token', error);
+    if (error instanceof AuthenticationError) throw error;
+    throw new AuthenticationError('Invalid refresh token');
   }
 };
 

--- a/src/services/auth/user.ts
+++ b/src/services/auth/user.ts
@@ -312,7 +312,7 @@ export const refreshUserToken = async (refreshToken: string) => {
   try {
     const decoded = verifyRefreshToken(refreshToken);
     const result = await prisma.user.findUnique({
-      where: { id: decoded.userId },
+      where: { id: decoded.userId, deleted_at: null },
     });
     if (!result) {
       throw new AuthenticationError('Access denied');
@@ -322,9 +322,16 @@ export const refreshUserToken = async (refreshToken: string) => {
       refreshToken: signRefreshToken(result.id),
     };
   } catch (error) {
-    logger.error('Error refreshing token', error);
     if (error instanceof AuthenticationError) throw error;
-    throw new AuthenticationError('Invalid refresh token');
+    if (
+      error instanceof jwt.JsonWebTokenError ||
+      error instanceof jwt.TokenExpiredError
+    ) {
+      logger.error('Error refreshing token', error);
+      throw new AuthenticationError('Invalid refresh token');
+    }
+    logger.error('Error refreshing token', error);
+    throw error;
   }
 };
 

--- a/tests/env-stub.ts
+++ b/tests/env-stub.ts
@@ -1,0 +1,8 @@
+const known: Record<string, string> = {
+  JWT_SECRET: 'test-access-secret',
+  REFRESH_TOKEN_SECRET: 'test-refresh-secret',
+};
+
+export const ENV = new Proxy(known, {
+  get: (target, prop: string) => (prop in target ? target[prop] : 'test-stub'),
+});

--- a/tests/login-controller.test.ts
+++ b/tests/login-controller.test.ts
@@ -52,6 +52,7 @@ describe('loginUser controller', () => {
       token: 'access-abc',
       refreshToken: 'refresh-abc',
     });
+    expect(res.cookie).not.toHaveBeenCalled();
   });
 
   it('keeps the web response unchanged (no tokens in body)', async () => {

--- a/tests/login-controller.test.ts
+++ b/tests/login-controller.test.ts
@@ -1,0 +1,70 @@
+import * as userController from '@/controllers/auth/user';
+import * as userService from '@/services/auth/user';
+import { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/auth/user', () => ({
+  loginUser: vi.fn(),
+}));
+vi.mock('@/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const USER_INFO = {
+  createdAt: new Date('2026-01-01'),
+  email: 'a@b.co',
+  firstName: 'Aung',
+  username: 'aung',
+  lastName: 'K',
+  userId: 'user-1',
+};
+
+const makeRes = (): Response =>
+  ({
+    cookie: vi.fn(),
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn(),
+  }) as unknown as Response;
+
+const body = { email: 'a@b.co', password: 'password123', rememberMe: true };
+
+describe('loginUser controller', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (userService.loginUser as ReturnType<typeof vi.fn>).mockResolvedValue({
+      refershToken: 'refresh-abc',
+      token: 'access-abc',
+      userInfo: USER_INFO,
+    });
+  });
+
+  it('includes tokens in the body for X-Client: mobile', async () => {
+    const req = {
+      body,
+      headers: { 'x-client': 'mobile' },
+    } as unknown as Request;
+    const res = makeRes();
+
+    await userController.loginUser(req, res, vi.fn() as NextFunction);
+
+    expect(res.json).toHaveBeenCalledWith({
+      ...USER_INFO,
+      token: 'access-abc',
+      refreshToken: 'refresh-abc',
+    });
+  });
+
+  it('keeps the web response unchanged (no tokens in body)', async () => {
+    const req = { body, headers: {} } as unknown as Request;
+    const res = makeRes();
+
+    await userController.loginUser(req, res, vi.fn() as NextFunction);
+
+    expect(res.json).toHaveBeenCalledWith(USER_INFO);
+    expect(res.cookie).toHaveBeenCalledWith(
+      'token',
+      'access-abc',
+      expect.any(Object),
+    );
+  });
+});

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -54,4 +54,11 @@ describe('refreshUserToken', () => {
       where: { id: 'user-1', deleted_at: null },
     });
   });
+
+  it('propagates infra errors instead of downgrading them to AuthenticationError', async () => {
+    findUnique.mockRejectedValue(new Error('db down'));
+    await expect(
+      refreshUserToken(signRefreshToken('user-1')),
+    ).rejects.not.toBeInstanceOf(AuthenticationError);
+  });
 });

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -32,9 +32,10 @@ describe('refreshUserToken', () => {
   });
 
   it('rejects an access token used as refresh token', async () => {
-    await expect(
-      refreshUserToken(signAccessToken('user-1')),
-    ).rejects.toBeInstanceOf(AuthenticationError);
+    findUnique.mockResolvedValue({ id: 'user-1' });
+    await expect(refreshUserToken(signAccessToken('user-1'))).rejects.toThrow(
+      'Invalid refresh token',
+    );
   });
 
   it('rejects when the user no longer exists', async () => {
@@ -42,5 +43,15 @@ describe('refreshUserToken', () => {
     await expect(
       refreshUserToken(signRefreshToken('ghost')),
     ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('rejects a valid refresh token for a soft-deleted user', async () => {
+    findUnique.mockResolvedValue(null);
+    await expect(
+      refreshUserToken(signRefreshToken('user-1')),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1', deleted_at: null },
+    });
   });
 });

--- a/tests/refresh.test.ts
+++ b/tests/refresh.test.ts
@@ -1,0 +1,46 @@
+import prisma from '@/libs/prisma';
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken,
+} from '@/services/auth/token-service';
+import { refreshUserToken } from '@/services/auth/user';
+import { AuthenticationError } from '@/utils/errors';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/libs/prisma', () => ({
+  default: { user: { findUnique: vi.fn() } },
+}));
+vi.mock('@/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const findUnique = prisma.user.findUnique as ReturnType<typeof vi.fn>;
+
+describe('refreshUserToken', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('returns a rotated token pair for a valid refresh token', async () => {
+    findUnique.mockResolvedValue({ id: 'user-1' });
+    const result = await refreshUserToken(signRefreshToken('user-1'));
+
+    expect(verifyAccessToken(result.token)).toMatchObject({ userId: 'user-1' });
+    expect(verifyRefreshToken(result.refreshToken)).toMatchObject({
+      userId: 'user-1',
+    });
+  });
+
+  it('rejects an access token used as refresh token', async () => {
+    await expect(
+      refreshUserToken(signAccessToken('user-1')),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+
+  it('rejects when the user no longer exists', async () => {
+    findUnique.mockResolvedValue(null);
+    await expect(
+      refreshUserToken(signRefreshToken('ghost')),
+    ).rejects.toBeInstanceOf(AuthenticationError);
+  });
+});

--- a/tests/secure-route.test.ts
+++ b/tests/secure-route.test.ts
@@ -1,0 +1,111 @@
+import { ENV } from '@/env';
+import prisma from '@/libs/prisma';
+import secureRoute from '@/middlewares/secure-route';
+import {
+  signAccessToken,
+  signRefreshToken,
+} from '@/services/auth/token-service';
+import { AuthenticationError } from '@/utils/errors';
+import { NextFunction, Request, Response } from 'express';
+import jwt from 'jsonwebtoken';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/libs/prisma', () => ({
+  default: { user: { findUnique: vi.fn() } },
+}));
+vi.mock('@/logger', () => ({
+  default: { error: vi.fn(), info: vi.fn(), warn: vi.fn() },
+}));
+
+const USER = { id: 'user-1', email: 'a@b.c' };
+const findUnique = prisma.user.findUnique as ReturnType<typeof vi.fn>;
+
+const makeReq = (over: Partial<Request> = {}): Request =>
+  ({ cookies: {}, headers: {}, ...over }) as unknown as Request;
+
+const makeRes = (): Response =>
+  ({ cookie: vi.fn(), clearCookie: vi.fn() }) as unknown as Response;
+
+describe('secureRoute', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('authenticates a valid Bearer token and sets req.user', async () => {
+    findUnique.mockResolvedValue(USER);
+    const req = makeReq({
+      headers: { authorization: `Bearer ${signAccessToken('user-1')}` },
+    } as never);
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, makeRes(), next);
+
+    expect(req.user).toEqual(USER);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('still authenticates a valid cookie token', async () => {
+    findUnique.mockResolvedValue(USER);
+    const req = makeReq({
+      cookies: { token: signAccessToken('user-1') },
+    } as never);
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, makeRes(), next);
+
+    expect(req.user).toEqual(USER);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects an expired Bearer token with "Token expired" and no cookie writes', async () => {
+    const expired = jwt.sign({ userId: 'user-1' }, ENV.JWT_SECRET, {
+      expiresIn: -10,
+    });
+    const req = makeReq({
+      headers: { authorization: `Bearer ${expired}` },
+    } as never);
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, res, next);
+
+    const err = (next as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toBe('Token expired');
+    expect(res.cookie).not.toHaveBeenCalled();
+    expect(res.clearCookie).not.toHaveBeenCalled();
+  });
+
+  it('refreshes cookies when cookie token expired and refresh cookie is valid (bugfix)', async () => {
+    findUnique.mockResolvedValue(USER);
+    const expired = jwt.sign({ userId: 'user-1' }, ENV.JWT_SECRET, {
+      expiresIn: -10,
+    });
+    const req = makeReq({
+      cookies: { token: expired, refreshToken: signRefreshToken('user-1') },
+    } as never);
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, res, next);
+
+    expect(res.cookie).toHaveBeenCalledWith(
+      'token',
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(res.cookie).toHaveBeenCalledWith(
+      'refreshToken',
+      expect.any(String),
+      expect.any(Object),
+    );
+    expect(req.user).toEqual(USER);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects when no token anywhere', async () => {
+    const next = vi.fn() as NextFunction;
+    await secureRoute()(makeReq(), makeRes(), next);
+    const err = (next as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toBe('Token is required');
+  });
+});

--- a/tests/secure-route.test.ts
+++ b/tests/secure-route.test.ts
@@ -160,4 +160,62 @@ describe('secureRoute', () => {
     expect(res.clearCookie).toHaveBeenCalledWith('refreshToken');
     expect(res.clearCookie).not.toHaveBeenCalledWith('token');
   });
+
+  it('rejects a valid, unexpired Bearer access token belonging to a soft-deleted user', async () => {
+    // The mock resolves null unconditionally, which is exactly what a
+    // deleted_at:null-filtered lookup for a soft-deleted user would return.
+    // That means the "rejected" assertion below would pass even against the
+    // pre-fix code (which never filters on deleted_at) as long as the mock
+    // returns null anyway. The discriminating assertion is the one on the
+    // findUnique call args: it proves the middleware actually included
+    // deleted_at: null in the where clause at this call site, not just that
+    // it handled a null result correctly.
+    findUnique.mockResolvedValue(null);
+    const req = makeReq({
+      headers: { authorization: `Bearer ${signAccessToken('user-1')}` },
+    } as never);
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, makeRes(), next);
+
+    const err = (next as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toBe('Access denied');
+    // Discriminating assertion: fails pre-fix because the middleware calls
+    // findUnique with only { id: decoded.userId }, omitting deleted_at.
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1', deleted_at: null },
+    });
+  });
+
+  it('rejects an expired cookie token plus a valid refresh cookie belonging to a soft-deleted user, and mints no new cookies', async () => {
+    // Same caveat as above: with an unconditional null mock, "rejected" and
+    // "no cookies minted" both hold even pre-fix, because the existing
+    // !result branch already declines to mint cookies for a null lookup.
+    // The discriminating assertion is the findUnique call-args check: it is
+    // the only one that fails against the pre-fix code, which looks up the
+    // refresh-token user by { id: decodedRefreshToken.userId } alone.
+    findUnique.mockResolvedValue(null);
+    const expired = jwt.sign({ userId: 'user-1' }, ENV.JWT_SECRET, {
+      expiresIn: -10,
+    });
+    const req = makeReq({
+      cookies: { token: expired, refreshToken: signRefreshToken('user-1') },
+    } as never);
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, res, next);
+
+    const err = (next as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toBe('Access denied');
+    expect(res.cookie).not.toHaveBeenCalled();
+    // Discriminating assertion: fails pre-fix because the middleware calls
+    // findUnique with only { id: decodedRefreshToken.userId }, omitting
+    // deleted_at.
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { id: 'user-1', deleted_at: null },
+    });
+  });
 });

--- a/tests/secure-route.test.ts
+++ b/tests/secure-route.test.ts
@@ -108,4 +108,56 @@ describe('secureRoute', () => {
     expect(err).toBeInstanceOf(AuthenticationError);
     expect(err.message).toBe('Token is required');
   });
+
+  it('rejects an expired cookie token with no refresh cookie as "Invalid token" and clears both cookies', async () => {
+    const expired = jwt.sign({ userId: 'user-1' }, ENV.JWT_SECRET, {
+      expiresIn: -10,
+    });
+    const req = makeReq({ cookies: { token: expired } } as never);
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, res, next);
+
+    const err = (next as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toBe('Invalid token');
+    expect(res.clearCookie).toHaveBeenCalledWith('token');
+    expect(res.clearCookie).toHaveBeenCalledWith('refreshToken');
+  });
+
+  it('prefers the cookie token when both cookie and Bearer are present, and never verifies the Bearer token', async () => {
+    findUnique.mockResolvedValue(USER);
+    const req = makeReq({
+      cookies: { token: signAccessToken('user-1') },
+      // Deliberately unverifiable: if precedence ever flipped to the Bearer
+      // token, verifying this would throw and next() would receive an error.
+      headers: { authorization: 'Bearer not-a-valid-jwt' },
+    } as never);
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, makeRes(), next);
+
+    expect(req.user).toEqual(USER);
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('rejects an expired cookie token with an invalid refresh cookie as "Invalid refresh token" and clears only refreshToken', async () => {
+    const expired = jwt.sign({ userId: 'user-1' }, ENV.JWT_SECRET, {
+      expiresIn: -10,
+    });
+    const req = makeReq({
+      cookies: { token: expired, refreshToken: 'not-a-valid-refresh-token' },
+    } as never);
+    const res = makeRes();
+    const next = vi.fn() as NextFunction;
+
+    await secureRoute()(req, res, next);
+
+    const err = (next as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(err).toBeInstanceOf(AuthenticationError);
+    expect(err.message).toBe('Invalid refresh token');
+    expect(res.clearCookie).toHaveBeenCalledWith('refreshToken');
+    expect(res.clearCookie).not.toHaveBeenCalledWith('token');
+  });
 });

--- a/tests/token-service.test.ts
+++ b/tests/token-service.test.ts
@@ -1,0 +1,38 @@
+import { ENV } from '@/env';
+import {
+  signAccessToken,
+  signRefreshToken,
+  verifyAccessToken,
+  verifyRefreshToken,
+} from '@/services/auth/token-service';
+import jwt, { TokenExpiredError } from 'jsonwebtoken';
+import { describe, expect, it } from 'vitest';
+
+describe('token-service', () => {
+  it('round-trips an access token', () => {
+    const token = signAccessToken('user-1');
+    expect(verifyAccessToken(token)).toMatchObject({ userId: 'user-1' });
+  });
+
+  it('round-trips a refresh token', () => {
+    const token = signRefreshToken('user-1');
+    expect(verifyRefreshToken(token)).toMatchObject({ userId: 'user-1' });
+  });
+
+  it('rejects a refresh token passed as an access token (different secrets)', () => {
+    const refresh = signRefreshToken('user-1');
+    expect(() => verifyAccessToken(refresh)).toThrow();
+  });
+
+  it('rejects an access token passed as a refresh token', () => {
+    const access = signAccessToken('user-1');
+    expect(() => verifyRefreshToken(access)).toThrow();
+  });
+
+  it('throws TokenExpiredError for an expired access token', () => {
+    const expired = jwt.sign({ userId: 'user-1' }, ENV.JWT_SECRET, {
+      expiresIn: -10,
+    });
+    expect(() => verifyAccessToken(expired)).toThrow(TokenExpiredError);
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,18 @@
+import path from 'node:path';
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  resolve: {
+    alias: [
+      {
+        find: '@/env',
+        replacement: path.resolve(__dirname, 'tests/env-stub.ts'),
+      },
+      { find: '@', replacement: path.resolve(__dirname, 'src') },
+    ],
+  },
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
Lets React Native clients authenticate with `Authorization: Bearer` alongside the existing httpOnly-cookie flow, and fixes two auth bugs found along the way. The web client's behaviour is unchanged apart from one deliberate change, called out below.

## Why

`secureRoute` read credentials only from `req.cookies`, and refresh happened as a side effect inside the middleware — browser mechanics a React Native client can't use or drive. This adds a Bearer path beside the cookie path rather than replacing it.

## What's in it

- **`src/services/auth/token-service.ts`** — single place where JWTs are signed and verified, so each secret has exactly one definition site.
- **`secureRoute` accepts `Authorization: Bearer`** alongside cookies. Cookies keep precedence when both are present, so nothing changes for the web client.
- **Login returns the token pair in the body only for `X-Client: mobile`**, and that path sets no cookies — the two paths are disjoint, so a mobile client can't silently end up on a cookie session it can't clear.
- **`POST /auth/refresh`** — unauthenticated by design (its caller holds an expired access token), returns a rotated pair.
- **vitest** — the repo's first test infrastructure. Note CI's existing "Run tests" step was hitting an always-green stub; it now runs a real suite for the first time.

## Bugfixes

**Refresh was completely broken in production.** Refresh tokens were signed with `REFRESH_TOKEN_SECRET` but verified with `JWT_SECRET`. Those differ in `.env`, so every refresh threw `Invalid refresh token` — users were being logged out roughly daily. Refresh cookies already in browsers start working the moment this deploys; no forced logout on release.

**Soft-deleted accounts were never actually revoked.** Neither `secureRoute` nor the new refresh path filtered `deleted_at`, so a deleted user kept up to 24h of API access and their web session renewed indefinitely. All four user lookups now filter it, matching `loginUser`.

## ⚠️ Behaviour change for the web client

Closing the soft-delete hole means **active web sessions belonging to soft-deleted accounts will start failing immediately** instead of lingering. That's the intent, but it's a live behaviour change worth knowing before merge.

It also removes the last self-service recovery window: `/users/:id/recover` sits behind `secureRoute`, which a deleted user can no longer pass. Worth deciding whether recovery needs an admin path or whether deletion should be documented as final.

## Verification

22 tests, `tsc --noEmit` clean. Also verified end-to-end against real Postgres and a running server: mobile login, Bearer-authenticated request, refresh rotation, the refresh bugfix proven live, the web path unchanged (cookies set, no tokens in a non-mobile body), bad input giving 401/400 rather than 500, and soft-delete revoking access, refresh, and login.

`pnpm lint` still flags ~10 unrelated files with pre-existing formatting debt, identical to `dev`. CI's `pnpm format` rewrites them first, so CI passes.

## Follow-ups

A few auth hardening items came out of review that are deliberately not in this PR — including one that predates it and one that's a product decision about session revocation. Sent separately rather than described here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches authentication, session refresh, and account revocation semantics; soft-deleted users lose API access and cookie auto-refresh immediately after deploy.
> 
> **Overview**
> Adds **mobile-friendly auth** alongside the existing cookie flow: `secureRoute` accepts `Authorization: Bearer` (cookies still win when both are present), login with `X-Client: mobile` returns `token` / `refreshToken` in the JSON body and skips `Set-Cookie`, and **`POST /auth/refresh`** rotates a pair from a body `refreshToken`. JWT sign/verify is centralized in **`token-service`** so access and refresh use the right secrets.
> 
> Fixes two production auth issues: **refresh verification** now uses `REFRESH_TOKEN_SECRET` (middleware cookie refresh was verifying with the access secret), and **user lookups** in `secureRoute` and refresh filter **`deleted_at: null`**, revoking soft-deleted accounts immediately (including active web sessions).
> 
> **Vitest** replaces the no-op `test` script; new tests cover token service, refresh, `secureRoute`, and mobile login behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f7542ac4ffa44cc295d12b8a72aa69694db5ef71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->